### PR TITLE
Slicing Plane in any direction

### DIFF
--- a/Assets/Scripts/VolumeObject/SlicingPlaneAnyDirection.cs
+++ b/Assets/Scripts/VolumeObject/SlicingPlaneAnyDirection.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+[ExecuteInEditMode]
+public class SlicingPlaneAnyDirection : MonoBehaviour
+{
+    public Material mat;
+    public Transform volumeTransform;
+
+    void Update()
+    {
+        mat.SetVector("_PlanePos", volumeTransform.position - transform.position);
+        mat.SetVector("_PlaneNormal", transform.forward);
+    }
+}

--- a/Assets/Scripts/VolumeObject/SlicingPlaneAnyDirection.cs.meta
+++ b/Assets/Scripts/VolumeObject/SlicingPlaneAnyDirection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 030645f63ce11d14ea77ce39291d70da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/DirectVolumeRenderingShader.shader
+++ b/Assets/Shaders/DirectVolumeRenderingShader.shader
@@ -48,6 +48,9 @@
             float _MinVal;
             float _MaxVal;
 
+			float3 _PlanePos;
+			float3 _PlaneNormal;
+
             // Gets the colour from a 1D Transfer Function (x = density)
             float4 getTF1DColour(float density)
             {
@@ -115,6 +118,18 @@
 #endif
                     if (density < _MinVal || density > _MaxVal)
                         src.a = 0.0f;
+
+					// Move the reference in the middle of the mesh, like the pivot
+					float3 pivotPos = currPos - float3(0.5f, 0.5f, 0.5f);
+
+					// Convert to world position
+					float3 pos = mul(unity_ObjectToWorld, -pivotPos);
+
+					// If the dot product is < 0, the current position is "below" the plane, if it's > 0 it's "above"
+					// Then cull if the current position is below
+					float cull = dot(_PlaneNormal, pos - _PlanePos);
+					if (cull < 0)
+						src.a = 0;
 
                     col.rgb = src.a * src.rgb + (1.0f - src.a)*col.rgb;
                     col.a = src.a + (1.0f - src.a)*col.a;

--- a/Assets/Shaders/DirectVolumeRenderingShader.shader
+++ b/Assets/Shaders/DirectVolumeRenderingShader.shader
@@ -48,8 +48,8 @@
             float _MinVal;
             float _MaxVal;
 
-			float3 _PlanePos;
-			float3 _PlaneNormal;
+            float3 _PlanePos;
+            float3 _PlaneNormal;
 
             // Gets the colour from a 1D Transfer Function (x = density)
             float4 getTF1DColour(float density)
@@ -119,17 +119,17 @@
                     if (density < _MinVal || density > _MaxVal)
                         src.a = 0.0f;
 
-					// Move the reference in the middle of the mesh, like the pivot
-					float3 pivotPos = currPos - float3(0.5f, 0.5f, 0.5f);
+                    // Move the reference in the middle of the mesh, like the pivot
+                    float3 pivotPos = currPos - float3(0.5f, 0.5f, 0.5f);
 
-					// Convert to world position
-					float3 pos = mul(unity_ObjectToWorld, -pivotPos);
+                    // Convert to world position
+                    float3 pos = mul(unity_ObjectToWorld, -pivotPos);
 
-					// If the dot product is < 0, the current position is "below" the plane, if it's > 0 it's "above"
-					// Then cull if the current position is below
-					float cull = dot(_PlaneNormal, pos - _PlanePos);
-					if (cull < 0)
-						src.a = 0;
+                    // If the dot product is < 0, the current position is "below" the plane, if it's > 0 it's "above"
+                    // Then cull if the current position is below
+                    float cull = dot(_PlaneNormal, pos - _PlanePos);
+                    if (cull < 0)
+                    	src.a = 0;
 
                     col.rgb = src.a * src.rgb + (1.0f - src.a)*col.rgb;
                     col.a = src.a + (1.0f - src.a)*col.a;


### PR DESCRIPTION
![SlicingPlaneAnyDirection](https://user-images.githubusercontent.com/7714364/73441117-c3d33700-4352-11ea-815c-82f819683174.gif)

Add support for slicing in any direction with a plane.

To use:
* Load your dataset
* Create a new quad (GameObject -> 3D Object -> Quad)
* Attach the script SlicingPlaneAnyDirection.cs to it
* Link the DirectVolumeRenderingMaterial material to the script
* Link the dataset Volume transform to the script
* Move/Rotate the quad around to slice the volume

Notes:
* I implemented my code only in the Direct Volume Rendering Render Mode part of the shader, feel free to implement it in other modes as well.