### PR TITLE
Compute Histogram on GPU

### DIFF
--- a/Assets/Editor/TransferFunctionEditorWindow.cs
+++ b/Assets/Editor/TransferFunctionEditorWindow.cs
@@ -79,7 +79,12 @@ namespace UnityVolumeRendering
             tf.GenerateTexture();
 
             if(histTex == null)
-                histTex = HistogramTextureGenerator.GenerateHistogramTextureOnGPU(volRendObject.dataset);
+            {
+                if(SystemInfo.supportsComputeShaders)
+                    histTex = HistogramTextureGenerator.GenerateHistogramTextureOnGPU(volRendObject.dataset);
+                else
+                    histTex = HistogramTextureGenerator.GenerateHistogramTexture(volRendObject.dataset);
+            }
 
             tfGUIMat.SetTexture("_TFTex", tf.GetTexture());
             tfGUIMat.SetTexture("_HistTex", histTex);

--- a/Assets/Editor/TransferFunctionEditorWindow.cs
+++ b/Assets/Editor/TransferFunctionEditorWindow.cs
@@ -79,7 +79,7 @@ namespace UnityVolumeRendering
             tf.GenerateTexture();
 
             if(histTex == null)
-                histTex = HistogramTextureGenerator.GenerateHistogramTexture(volRendObject.dataset);
+                histTex = HistogramTextureGenerator.GenerateHistogramTextureOnGPU(volRendObject.dataset);
 
             tfGUIMat.SetTexture("_TFTex", tf.GetTexture());
             tfGUIMat.SetTexture("_HistTex", histTex);

--- a/Assets/Resources/ComputeHistogram.compute
+++ b/Assets/Resources/ComputeHistogram.compute
@@ -1,7 +1,8 @@
 ﻿#pragma kernel HistogramInitialize
 #pragma kernel HistogramMain
 
-Texture3D<float4> VolumeTexture;
+Texture3D<float> VolumeTexture;
+float ValueRange;
 
 struct histStruct {
 	uint cnt;
@@ -17,7 +18,7 @@ void HistogramInitialize(uint3 id : SV_DispatchThreadID)
 [numthreads(8, 8, 8)]
 void HistogramMain(uint3 id : SV_DispatchThreadID)
 {
-	uint col = uint(255.0 * VolumeTexture[id.xyz].r);
+	uint col = uint(floor(ValueRange * VolumeTexture[id.xyz] + 0.5f));
 
 	InterlockedAdd(HistogramBuffer[col].cnt, 1);
 }

--- a/Assets/Resources/ComputeHistogram.compute
+++ b/Assets/Resources/ComputeHistogram.compute
@@ -1,0 +1,23 @@
+﻿#pragma kernel HistogramInitialize
+#pragma kernel HistogramMain
+
+Texture3D<float4> VolumeTexture;
+
+struct histStruct {
+	uint cnt;
+};
+RWStructuredBuffer<histStruct> HistogramBuffer;
+
+[numthreads(8, 1, 1)]
+void HistogramInitialize(uint3 id : SV_DispatchThreadID)
+{
+	HistogramBuffer[id.x].cnt = uint(0);
+}
+
+[numthreads(8, 8, 8)]
+void HistogramMain(uint3 id : SV_DispatchThreadID)
+{
+	uint col = uint(255.0 * VolumeTexture[id.xyz].r);
+
+	InterlockedAdd(HistogramBuffer[col].cnt, 1);
+}

--- a/Assets/Resources/ComputeHistogram.compute.meta
+++ b/Assets/Resources/ComputeHistogram.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90e61867e921489469b4826c129bde04
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
NOTE:
- Result seems to be broken for some reason (probably texture format)
- Supports only 8-bit data

The histogram have unexpected spikes and holes. I suspect the Texture3D format to be the issue:
`uint col = uint(255.0 * VolumeTexture[id.xyz].r);`
With this line a convert 0-1 range to 0-255 range, but it seems to miss/shift some numbers.
I tried to change the Texture format from RHalf to R8 and Alpha8, I had different result but still broken. In my application I use Alpha8 and it is working fine so idk what's wrong, trying with other datasets might worth a try (I tried only the 2 provided with the repo).

Also my code is for 8-bit data ONLY (0-255 range) (working in VR, 16-bit is way to heavy for no visual gain)

Feel free to take a look at the code, change GenerateHistogramTextureOnGPU to GenerateHistogramTexture in TransferFunctionEditorWindow.cs to switch between the 2. I'm no expert at compute shader, I learned while doing this couple months ago.
GPU is faster, but data being quite small the difference is not big, I believe the gain will be bigger for large dataset.