### PR TITLE
replaced ScriptableObject inheritance with getters and setters

### DIFF
--- a/Assets/Scripts/Importing/DICOMImporter.cs
+++ b/Assets/Scripts/Importing/DICOMImporter.cs
@@ -78,7 +78,7 @@ namespace UnityVolumeRendering
 
             // Create dataset
             VolumeDataset dataset = new VolumeDataset();
-            dataset.name = Path.GetFileName(Path.GetDirectoryName(diroctoryPath));
+            dataset.datasetName = Path.GetFileName(Path.GetDirectoryName(diroctoryPath));
             dataset.dimX = files[0].file.PixelData.Columns;
             dataset.dimY = files[0].file.PixelData.Rows;
             dataset.dimZ = files.Count;

--- a/Assets/Scripts/Importing/ImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter.cs
@@ -160,7 +160,6 @@ namespace UnityVolumeRendering
 
             VolumeDataset dataset = new VolumeDataset()
             {
-                name = name,
                 datasetName = name,
                 data = data,
                 dimX = dimensions.x,

--- a/Assets/Scripts/TransferFunction/TransferFunction.cs
+++ b/Assets/Scripts/TransferFunction/TransferFunction.cs
@@ -5,7 +5,7 @@ using System;
 namespace UnityVolumeRendering
 {
     [Serializable]
-    public class TransferFunction : ScriptableObject
+    public class TransferFunction
     {
         [SerializeField]
         public List<TFColourControlPoint> colourControlPoints = new List<TFColourControlPoint>();

--- a/Assets/Scripts/TransferFunction/TransferFunction2D.cs
+++ b/Assets/Scripts/TransferFunction/TransferFunction2D.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace UnityVolumeRendering
 {
     [Serializable]
-    public class TransferFunction2D : ScriptableObject
+    public class TransferFunction2D
     {
         [System.Serializable]
         public struct TF2DBox

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityVolumeRendering
 {
     [Serializable]
-    public class VolumeDataset : ScriptableObject
+    public class VolumeDataset
     {
         [SerializeField]
         public int[] data = null;

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -5,17 +5,17 @@ namespace UnityVolumeRendering
     [ExecuteInEditMode]
     public class VolumeRenderedObject : MonoBehaviour
     {
-        [HideInInspector]
-        public TransferFunction transferFunction;
-
-        [HideInInspector]
-        public TransferFunction2D transferFunction2D;
-
-        [HideInInspector]
-        public VolumeDataset dataset;
-
-        [HideInInspector]
-        public MeshRenderer meshRenderer;
+        /*
+         * Getters and setters are required for these public fields
+         * in order to force Unity not to serialise their values on
+         * inspector GUI updates. The [HideInInspector] flag hides
+         * them but does not stop serialisation.
+         */
+            
+        public TransferFunction transferFunction { get; set; }
+        public TransferFunction2D transferFunction2D { get; set; }
+        public VolumeDataset dataset { get; set; }
+        public MeshRenderer meshRenderer { get; set; }
 
         private RenderMode renderMode;
         private TFRenderMode tfRenderMode;


### PR DESCRIPTION
From documentation on VolumeRenderedObject:

```
/*
 * Getters and setters are required for these public fields
 * in order to force Unity not to serialise their values on
 * inspector GUI updates. The [HideInInspector] flag hides
 * them but does not stop serialisation.
 */
```