### PR TITLE
Import DICOM without DICOM file extension

### DIFF
--- a/Assets/Editor/EditorDatasetImporter.cs
+++ b/Assets/Editor/EditorDatasetImporter.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using UnityEditor;
 
 namespace UnityVolumeRendering
@@ -23,7 +26,13 @@ namespace UnityVolumeRendering
                     }
                 case DatasetType.DICOM:
                     {
-                        DatasetImporterBase importer = new DICOMImporter(new FileInfo(filePath).Directory.FullName, false);
+                        string directoryPath = new FileInfo(filePath).Directory.FullName;
+
+                        // Find all DICOM files in directory
+                        IEnumerable<string> fileCandidates = Directory.EnumerateFiles(directoryPath, "*.*", SearchOption.TopDirectoryOnly)
+                            .Where(p => p.EndsWith(".dcm", StringComparison.InvariantCultureIgnoreCase) || p.EndsWith(".dicom", StringComparison.InvariantCultureIgnoreCase) || p.EndsWith(".dicm", StringComparison.InvariantCultureIgnoreCase));
+
+                        DatasetImporterBase importer = new DICOMImporter(fileCandidates, Path.GetFileName(directoryPath));
                         VolumeDataset dataset = importer.Import();
 
                         if (dataset != null)

--- a/Assets/Scripts/GUI/Components/RuntimeGUI.cs
+++ b/Assets/Scripts/GUI/Components/RuntimeGUI.cs
@@ -1,4 +1,8 @@
-﻿using UnityEngine;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
 
 namespace UnityVolumeRendering
 {
@@ -67,8 +71,14 @@ namespace UnityVolumeRendering
                 // We'll only allow one dataset at a time in the runtime GUI (for simplicity)
                 DespawnAllDatasets();
 
+                bool recursive = true;
+
+                // Read all files
+                IEnumerable<string> fileCandidates = Directory.EnumerateFiles(result.path, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+                    .Where(p => p.EndsWith(".dcm", StringComparison.InvariantCultureIgnoreCase) || p.EndsWith(".dicom", StringComparison.InvariantCultureIgnoreCase) || p.EndsWith(".dicm", StringComparison.InvariantCultureIgnoreCase));
+
                 // Import the dataset
-                DICOMImporter importer = new DICOMImporter(result.path, true);
+                DICOMImporter importer = new DICOMImporter(fileCandidates, Path.GetFileName(result.path));
                 VolumeDataset dataset = importer.Import();
                 // Spawn the object
                 if (dataset != null)

--- a/Assets/Scripts/Importing/DICOMImporter.cs
+++ b/Assets/Scripts/Importing/DICOMImporter.cs
@@ -28,13 +28,13 @@ namespace UnityVolumeRendering
             public float pixelSpacing = 0.0f;
         }
 
-        private string diroctoryPath;
-        private bool recursive;
+        private IEnumerable<string> fileCandidates;
+        private string datasetName;
 
-        public DICOMImporter(string diroctoryPath, bool recursive)
+        public DICOMImporter(IEnumerable<string> files, string name = "DICOM_Dataset")
         {
-            this.diroctoryPath = diroctoryPath;
-            this.recursive = recursive;
+            this.fileCandidates = files;
+            datasetName = name;
         }
 
         public override VolumeDataset Import()
@@ -52,9 +52,6 @@ namespace UnityVolumeRendering
                 return null;
             }
 
-            // Read all files
-            IEnumerable<string> fileCandidates = Directory.EnumerateFiles(diroctoryPath, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
-                .Where(p => p.EndsWith(".dcm") || p.EndsWith(".dicom") || p.EndsWith(".dicm"));
             List<DICOMSliceFile> files = new List<DICOMSliceFile>();
             foreach (string filePath in fileCandidates)
             {
@@ -79,7 +76,7 @@ namespace UnityVolumeRendering
 
             // Create dataset
             VolumeDataset dataset = new VolumeDataset();
-            dataset.name = Path.GetFileName(Path.GetDirectoryName(diroctoryPath));
+            dataset.datasetName = Path.GetFileName(datasetName);
             dataset.dimX = files[0].file.PixelData.Columns;
             dataset.dimY = files[0].file.PixelData.Rows;
             dataset.dimZ = files.Count;


### PR DESCRIPTION
Moved DICOM directory content iteration out of DICOMImporter.
Added support for importing DICOM files without DICOM file extension (".dcm"/".dicom").
Fixed DICOM dataset name.