### PR TITLE
Fixed some Texture2D memory leak issues

### DIFF
--- a/Assets/Scripts/Importing/ImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter.cs
@@ -102,7 +102,7 @@ namespace UnityVolumeRendering
                 x = texture.width,
                 y = texture.height
             };
-
+            Texture2D.DestroyImmediate(texture);
             return dimensions;
         }
 
@@ -144,7 +144,7 @@ namespace UnityVolumeRendering
 
                 data.AddRange(imageData);
             }
-
+            Texture2D.DestroyImmediate(texture);
             return data.ToArray();
         }
 


### PR DESCRIPTION
Added some immediate Texture2D asset destruction for Image sequence importing. Destruction must be immediate, or an Out of Memory error may occur in between frames if the importing occurs in-game.