### PR TITLE
#60 Ensure dataset does not exceed max limit.

### DIFF
--- a/Assets/Scripts/Importing/DICOMImporter.cs
+++ b/Assets/Scripts/Importing/DICOMImporter.cs
@@ -156,6 +156,8 @@ namespace UnityVolumeRendering
                 dataset.scaleZ = Mathf.Abs(files[files.Count - 1].location - files[0].location);
             }
 
+            dataset.FixDimensions();
+
             return dataset;
         }
 

--- a/Assets/Scripts/Importing/ImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter.cs
@@ -36,6 +36,8 @@ namespace UnityVolumeRendering
             int[] data = FillSequentialData(dimensions, imagePaths);
             VolumeDataset dataset = FillVolumeDataset(data, dimensions);
 
+            dataset.FixDimensions();
+
             return dataset;
         }
 

--- a/Assets/Scripts/Importing/RawDatasetImporter.cs
+++ b/Assets/Scripts/Importing/RawDatasetImporter.cs
@@ -85,6 +85,9 @@ namespace UnityVolumeRendering
 
             reader.Close();
             fs.Close();
+
+            dataset.FixDimensions();
+            
             return dataset;
         }
 


### PR DESCRIPTION
Check if dataset exceeds max limit, and crop it if it does. This is a temporary solution. Later, we should try to downsample it instead.

This should "fix" #60 , but depending on how much the dataset exceeds the max dimension, you might end up with an incomplete dataset (since we cut away a the exceeding part of it).