### PR TITLE
Reduced OutOfMemory exceptions for importing large datasets

### DIFF
--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -120,7 +120,7 @@ namespace UnityVolumeRendering
             bool isHalfFloat = texformat == TextureFormat.RHalf;
             try
             {
-                // Create a bute array for filling the texture. Store has half (16 bit) or single (32 bit) float values.
+                // Create a byte array for filling the texture. Store has half (16 bit) or single (32 bit) float values.
                 int sampleSize = isHalfFloat ? 2 : 4;
                 byte[] bytes = new byte[data.Length * sampleSize]; // This can cause OutOfMemoryException
                 for (int iData = 0; iData < data.Length; iData++)


### PR DESCRIPTION
Hi

This pull request aims to reduce the number of unnecessary large arrays to avoid OutOfMemory exceptions for large datasets.

I had OutOfMemory exceptions on the cols arrays when I was trying to import a large dataset (512x512x1896). The current catch the exception with the cost of more processing time. It takes about 3 minutes to import the dataset with this system's specs: 
Intel Corei9-7960x
64 GB of RAM
NVidia GeForce RTX 2070

However, the same thing can be done for other parts of the program, for example reading the data but for now this edit was enough for me, unless anyone has issues with other parts as well.