### PR TITLE
DICOM time format fix

### DIFF
--- a/Assets/3rdparty/openDicom/Encoding/TM.cs
+++ b/Assets/3rdparty/openDicom/Encoding/TM.cs
@@ -73,14 +73,15 @@ namespace openDicom.Encoding
                         }
                         catch (Exception e)
                         {
-                            throw new EncodingException(
-                                "Time format is invalid.",
-                                Tag, Name + "/item", item);
+                            UnityEngine.Debug.LogWarning($"Date time format is invalid. tag: {Tag}, name: {Name}, item: {item}");
+                            time[i] = TimeSpan.Zero;
                         }
                     }
                     else
-                        throw new EncodingException("Time format is invalid.",
-                            Tag, Name + "/item", item);
+                    {
+                        UnityEngine.Debug.LogWarning($"Time format is invalid. tag: {Tag}, name: {Name}, item: {item}");
+                        time[i] = TimeSpan.Zero;
+                    }
                 }
             }
             return time;


### PR DESCRIPTION
#77: Log a warning instead of throwing EncodingException if time format is invalid (we don't use that anyway).