### PR TITLE
1D Transfer function improvements

### DIFF
--- a/Assets/Editor/TransferFunctionEditorWindow.cs
+++ b/Assets/Editor/TransferFunctionEditorWindow.cs
@@ -231,9 +231,9 @@ namespace UnityVolumeRendering
             if(GUI.Button(new Rect(histRect.x + 150.0f, histRect.y + histRect.height + 50.0f, 70.0f, 30.0f), "Clear"))
             {
                 tf = volRendObject.transferFunction = new TransferFunction();
-                tf.alphaControlPoints.Add(new TFAlphaControlPoint(0.1f, 0.0f));
-                tf.alphaControlPoints.Add(new TFAlphaControlPoint(0.9f, 1.0f));
-                tf.colourControlPoints.Add(new TFColourControlPoint(0.5f, Color.red));
+                tf.alphaControlPoints.Add(new TFAlphaControlPoint(0.2f, 0.0f));
+                tf.alphaControlPoints.Add(new TFAlphaControlPoint(0.8f, 1.0f));
+                tf.colourControlPoints.Add(new TFColourControlPoint(0.5f, new Color(0.469f, 0.354f, 0.223f, 1.0f)));
                 selectedColPointIndex = -1;
             }
 

--- a/Assets/Scripts/TransferFunction/TransferFunction.cs
+++ b/Assets/Scripts/TransferFunction/TransferFunction.cs
@@ -81,6 +81,9 @@ namespace UnityVolumeRendering
                 float tCol = (Mathf.Clamp(t, leftCol.dataValue, rightCol.dataValue) - leftCol.dataValue) / (rightCol.dataValue - leftCol.dataValue);
                 float tAlpha = (Mathf.Clamp(t, leftAlpha.dataValue, rightAlpha.dataValue) - leftAlpha.dataValue) / (rightAlpha.dataValue - leftAlpha.dataValue);
 
+                tCol = Mathf.SmoothStep(0.0f, 1.0f, tCol);
+                tAlpha = Mathf.SmoothStep(0.0f, 1.0f, tAlpha);
+
                 Color pixCol = rightCol.colourValue * tCol + leftCol.colourValue * (1.0f - tCol);
                 pixCol.a = rightAlpha.alphaValue * tAlpha + leftAlpha.alphaValue * (1.0f - tAlpha);
 


### PR DESCRIPTION
### Improvements to 1D transer function editor
![tf-improvements](https://user-images.githubusercontent.com/6906872/147886321-b4e0eb4e-5f70-4fd7-a0a0-89981126c726.png)

**Improvements:**
- Use smoothstep instead of LERP for TF alpha values.
- Made control points more visible, and centred them at the actual point.
- Made it easier to select control points (you now just need to click somewhere near them).
- Added a "clear" button.