### PR TITLE
#87: Don't re-create data texture or gradient texture if it already exists.

### DIFF
--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -35,13 +35,15 @@ namespace UnityVolumeRendering
         
         public Texture3D GetDataTexture()
         {
-            dataTexture = CreateTextureInternal();
+            if (dataTexture == null)
+                dataTexture = CreateTextureInternal();
             return dataTexture;
         }
 
         public Texture3D GetGradientTexture()
         {
-            gradientTexture = CreateGradientTextureInternal();
+            if (gradientTexture == null)
+                gradientTexture = CreateGradientTextureInternal();
             return gradientTexture;
         }
 


### PR DESCRIPTION
#87: Don't re-create data texture or gradient texture if it already exists. This was a terrible waste of performance.