### PR TITLE
Raymarching improvements

### DIFF
--- a/Assets/Shaders/DirectVolumeRenderingShader.shader
+++ b/Assets/Shaders/DirectVolumeRenderingShader.shader
@@ -188,6 +188,7 @@
                 float3 rayEndPos = rayStartPos + rayDir * aabbInters.y;
 
                 const uint numSteps = (uint)(abs(aabbInters.x - aabbInters.y) / stepSize);
+                const float numStepsRecip = 1.0 / numSteps;
 
                 // Create a small random offset in order to remove artifacts
                 rayStartPos += (2.0f * rayDir * stepSize) * tex2D(_NoiseTex, float2(i.uv.x, i.uv.y)).r;
@@ -196,7 +197,7 @@
                 float tDepth = 0.0;
                 for (uint iStep = 0; iStep < numSteps; iStep++)
                 {
-                    const float t = iStep * stepSize;
+                    const float t = iStep * numStepsRecip;
                     const float3 currPos = lerp(rayStartPos, rayEndPos, t);
 
                     // Perform slice culling (cross section plane)
@@ -260,12 +261,13 @@
                 float2 aabbInters = intersectAABB(rayStartPos, rayDir, float3(0.0, 0.0, 0.0), float3(1.0f, 1.0f, 1.0));
                 float3 rayEndPos = rayStartPos + rayDir * aabbInters.y;
                 const uint numSteps = (uint)(abs(aabbInters.x - aabbInters.y) / stepSize);
+                const float numStepsRecip = 1.0 / numSteps;
 
                 float maxDensity = 0.0f;
                 float3 maxDensityPos = rayStartPos;
                 for (uint iStep = 0; iStep < numSteps; iStep++)
                 {
-                    const float t = iStep * stepSize;
+                    const float t = iStep * numStepsRecip;
                     const float3 currPos = lerp(rayStartPos, rayEndPos, t);
                     
 #ifdef CUTOUT_ON
@@ -309,11 +311,12 @@
                 // Create a small random offset in order to remove artifacts
                 rayStartPos = rayStartPos + (2.0f * rayDir * stepSize) * tex2D(_NoiseTex, float2(i.uv.x, i.uv.y)).r;
                 const uint numSteps = (uint)(abs(aabbInters.x - aabbInters.y) / stepSize);
+                const float numStepsRecip = 1.0 / numSteps;
 
                 float4 col = float4(0,0,0,0);
                 for (uint iStep = 0; iStep < numSteps; iStep++)
                 {
-                    const float t = iStep * stepSize;
+                    const float t = iStep * numStepsRecip;
                     const float3 currPos = lerp(rayStartPos, rayEndPos, t);
                     
 #ifdef CUTOUT_ON

--- a/Assets/Shaders/DirectVolumeRenderingShader.shader
+++ b/Assets/Shaders/DirectVolumeRenderingShader.shader
@@ -261,6 +261,7 @@
                 float stepSize = 1.0 / NUM_STEPS;
 
                 float maxDensity = 0.0f;
+                float3 maxDensityPos = rayStartPos;
                 for (uint iStep = 0; iStep < NUM_STEPS; iStep++)
                 {
                     const float t = iStep * stepSize;
@@ -272,15 +273,18 @@
 #endif
 
                     const float density = getDensity(currPos);
-                    if (density > _MinVal && density < _MaxVal)
-                        maxDensity = max(density, maxDensity);
+                    if (density > maxDensity && density > _MinVal && density < _MaxVal)
+                    {
+                        maxDensity = density;
+                        maxDensityPos = currPos;
+                    }
                 }
 
                 // Write fragment output
                 frag_out output;
                 output.colour = float4(1.0f, 1.0f, 1.0f, maxDensity); // maximum intensity
 #if DEPTHWRITE_ON
-                output.depth = localToDepth(i.vertexLocal);
+                output.depth = localToDepth(maxDensityPos - float3(0.5f, 0.5f, 0.5f));
 #endif
                 return output;
             }


### PR DESCRIPTION
#85 

**Changes:**
- Find intersections with AABB and raymarch between these points.
- Removed branching boundary checks
- Replaced various if-checks with non-branching alternatives, for better performance.
- Use front-to-back raymarching in isosurface rendering mode.
- Fixed maximum intensity projection depth write (write the depth of the sample of maximum density)

TODO: Use front-to-back raymarching in direct volume rendering mode as well?