### PR TITLE
Serialised private fields, fixed depth in front-to-back volume rendering

### DIFF
--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -5,26 +5,31 @@ namespace UnityVolumeRendering
     [ExecuteInEditMode]
     public class VolumeRenderedObject : MonoBehaviour
     {
-        [HideInInspector]
+        [SerializeField, HideInInspector]
         public TransferFunction transferFunction;
 
-        [HideInInspector]
+        [SerializeField, HideInInspector]
         public TransferFunction2D transferFunction2D;
 
-        [HideInInspector]
+        [SerializeField, HideInInspector]
         public VolumeDataset dataset;
 
-        [HideInInspector]
+        [SerializeField, HideInInspector]
         public MeshRenderer meshRenderer;
 
+        [SerializeField, HideInInspector]
         private RenderMode renderMode;
+        [SerializeField, HideInInspector]
         private TFRenderMode tfRenderMode;
+        [SerializeField, HideInInspector]
         private bool lightingEnabled;
 
+        [SerializeField, HideInInspector]
         private Vector2 visibilityWindow = new Vector2(0.0f, 1.0f);
-
+        [SerializeField, HideInInspector]
         private bool rayTerminationEnabled = true;
-        private bool dvrBackward = true;
+        [SerializeField, HideInInspector]
+        private bool dvrBackward = false;
 
         public SlicingPlane CreateSlicingPlane()
         {

--- a/Assets/Shaders/DirectVolumeRenderingShader.shader
+++ b/Assets/Shaders/DirectVolumeRenderingShader.shader
@@ -302,7 +302,7 @@
                     src.rgb *= src.a;
                     col = (1.0f - col.a) * src + col;
 
-                    if (src.a > 0.15 && t < tDepth) {
+                    if (col.a > 0.15 && t < tDepth) {
                         tDepth = t;
                     }
 #endif


### PR DESCRIPTION
1- Unity serialises `Public` fields by default, but `private` fields need explicit serialisation. Otherwise, the settings are discarded in game mode or after restarting Unity. Since it is a good practice to change all `public` fields in 'VolumeRenderedObject' to `private` later, all `public` fields are also annotated with `[SerializeField]`.
2- Front-to-back is enabled by default. 
3- Comparing the accumulated colour for depth calculation in Front-to-Back rendering. However, we cannot do the same in Back-to-Front rendering.