### PR TITLE
Properly handle coordinate systems on import

### DIFF
--- a/Assets/Editor/SliceRenderingEditorWindow.cs
+++ b/Assets/Editor/SliceRenderingEditorWindow.cs
@@ -218,7 +218,7 @@ namespace UnityVolumeRendering
         private Vector3 GetDataPosition(Vector2 relativeMousePosition, SlicingPlane slicingPlane)
         {
             Vector3 worldSpacePosition = GetWorldPosition(relativeMousePosition, slicingPlane);
-            Vector3 objSpacePoint = slicingPlane.targetObject.transform.InverseTransformPoint(worldSpacePosition);
+            Vector3 objSpacePoint = slicingPlane.targetObject.volumeContainerObject.transform.InverseTransformPoint(worldSpacePosition);
             Vector3 uvw = objSpacePoint + Vector3.one * 0.5f;
             VolumeDataset dataset = slicingPlane.targetObject.dataset;
             return new Vector3(uvw.x * dataset.scale.x, uvw.y * dataset.scale.y, uvw.z * dataset.scale.z);
@@ -227,7 +227,7 @@ namespace UnityVolumeRendering
         private float GetValueAtPosition(Vector2 relativeMousePosition, SlicingPlane slicingPlane)
         {
             Vector3 worldSpacePosition = GetWorldPosition(relativeMousePosition, slicingPlane);
-            Vector3 objSpacePoint = slicingPlane.targetObject.transform.InverseTransformPoint(worldSpacePosition);
+            Vector3 objSpacePoint = slicingPlane.targetObject.volumeContainerObject.transform.InverseTransformPoint(worldSpacePosition);
             VolumeDataset dataset = slicingPlane.targetObject.dataset;
             // Convert to texture coordinates.
             Vector3 uvw = objSpacePoint + Vector3.one * 0.5f;

--- a/Assets/Editor/SliceRenderingEditorWindow.cs
+++ b/Assets/Editor/SliceRenderingEditorWindow.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEditor;
+using System.Linq;
 
 namespace UnityVolumeRendering
 {
@@ -62,6 +63,13 @@ namespace UnityVolumeRendering
 
             if (spawnedPlanes.Length > 0)
                 selectedPlaneIndex = selectedPlaneIndex % spawnedPlanes.Length;
+            
+            if (Selection.activeGameObject != null)
+            {
+                int index = System.Array.FindIndex(spawnedPlanes, plane => plane.gameObject == Selection.activeGameObject);
+                if (index != -1)
+                    selectedPlaneIndex = index;
+            }
 
             if (GUI.Toggle(new Rect(0.0f, 0.0f, 40.0f, 40.0f), inputMode == InputMode.Move, new GUIContent(moveIconTexture, "Move slice"), GUI.skin.button))
                 inputMode = InputMode.Move;

--- a/Assets/Editor/SliceRenderingEditorWindow.cs
+++ b/Assets/Editor/SliceRenderingEditorWindow.cs
@@ -169,19 +169,22 @@ namespace UnityVolumeRendering
                 if (GUI.Button(new Rect(200.0f, bgRect.y + bgRect.height + 0.0f, 120.0f, 20.0f), "Create XY plane"))
                 {
                     selectedPlaneIndex = spawnedPlanes.Length;
-                    volRend.CreateSlicingPlane();
+                    SlicingPlane plane = volRend.CreateSlicingPlane();
+                    UnityEditor.Selection.objects = new UnityEngine.Object[] { plane.gameObject };
                 }
                 else if (GUI.Button(new Rect(200.0f, bgRect.y + bgRect.height + 20.0f, 120.0f, 20.0f), "Create XZ plane"))
                 {
                     selectedPlaneIndex = spawnedPlanes.Length;
                     SlicingPlane plane = volRend.CreateSlicingPlane();
                     plane.transform.localRotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
+                    UnityEditor.Selection.objects = new UnityEngine.Object[] { plane.gameObject };
                 }
                 else if (GUI.Button(new Rect(200.0f, bgRect.y + bgRect.height + 40.0f, 120.0f, 20.0f), "Create ZY plane"))
                 {
                     selectedPlaneIndex = spawnedPlanes.Length;
                     SlicingPlane plane = volRend.CreateSlicingPlane();
                     plane.transform.localRotation = Quaternion.Euler(0.0f, 0.0f, 90.0f);
+                    UnityEditor.Selection.objects = new UnityEngine.Object[] { plane.gameObject };
                 }
             }
 

--- a/Assets/Editor/SliceRenderingEditorWindow.cs
+++ b/Assets/Editor/SliceRenderingEditorWindow.cs
@@ -77,7 +77,7 @@ namespace UnityVolumeRendering
                 SlicingPlane planeObj = spawnedPlanes[System.Math.Min(selectedPlaneIndex, spawnedPlanes.Length - 1)];
                 Vector3 planeScale = planeObj.transform.lossyScale;
                 
-                float heightWidthRatio = planeScale.z / planeScale.x;
+                float heightWidthRatio = Mathf.Abs(planeScale.z / planeScale.x);
                 float bgWidth = Mathf.Min(this.position.width - 20.0f, (this.position.height - 50.0f) * 2.0f);
                 float bgHeight = Mathf.Min(bgWidth, this.position.height - 150.0f);
                 bgWidth = bgHeight / heightWidthRatio;
@@ -102,7 +102,7 @@ namespace UnityVolumeRendering
                 {
                     Vector2 mouseOffset = relMousePosNormalised - prevMousePos;
                     if (Mathf.Abs(mouseOffset.y) > 0.00001f)
-                        planeObj.transform.Translate(Vector3.up * mouseOffset.y, Space.World);
+                        planeObj.transform.Translate(planeObj.transform.up * mouseOffset.y, Space.World);
                 }
                 // Show value at mouse position.
                 else if (inputMode == InputMode.Inspect)
@@ -152,7 +152,7 @@ namespace UnityVolumeRendering
                 
                 if (GUI.Button(new Rect(0.0f, bgRect.y + bgRect.height + 40.0f, 70.0f, 20.0f), "<"))
                 {
-                    selectedPlaneIndex = (selectedPlaneIndex - 1) % spawnedPlanes.Length;
+                    selectedPlaneIndex = selectedPlaneIndex == 0 ? spawnedPlanes.Length - 1 : selectedPlaneIndex - 1;
                     Selection.activeGameObject = spawnedPlanes[selectedPlaneIndex].gameObject;
                 }
                 if (GUI.Button(new Rect(90.0f, bgRect.y + bgRect.height + 40.0f, 70.0f, 20.0f), ">"))

--- a/Assets/Editor/SliceRenderingEditorWindow.cs
+++ b/Assets/Editor/SliceRenderingEditorWindow.cs
@@ -102,7 +102,7 @@ namespace UnityVolumeRendering
                 {
                     Vector2 mouseOffset = relMousePosNormalised - prevMousePos;
                     if (Mathf.Abs(mouseOffset.y) > 0.00001f)
-                        planeObj.transform.Translate(Vector3.up * mouseOffset.y);
+                        planeObj.transform.Translate(Vector3.up * mouseOffset.y, Space.World);
                 }
                 // Show value at mouse position.
                 else if (inputMode == InputMode.Inspect)
@@ -218,7 +218,7 @@ namespace UnityVolumeRendering
             Vector3 objSpacePoint = slicingPlane.targetObject.transform.InverseTransformPoint(worldSpacePosition);
             Vector3 uvw = objSpacePoint + Vector3.one * 0.5f;
             VolumeDataset dataset = slicingPlane.targetObject.dataset;
-            return new Vector3(uvw.x * dataset.scaleX, uvw.y * dataset.scaleY,uvw.z * dataset.scaleZ);
+            return new Vector3(uvw.x * dataset.scale.x, uvw.y * dataset.scale.y, uvw.z * dataset.scale.z);
         }
 
         private float GetValueAtPosition(Vector2 relativeMousePosition, SlicingPlane slicingPlane)

--- a/Assets/Scripts/Importing/ImageFileImporter/Interface/SimpleITK.meta
+++ b/Assets/Scripts/Importing/ImageFileImporter/Interface/SimpleITK.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 2a823b11bfaf79741bf3312984c336fe
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Importing/ImageFileImporter/Nifti.NET/NiftiImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/Nifti.NET/NiftiImporter.cs
@@ -79,6 +79,7 @@ namespace UnityVolumeRendering
             volumeDataset.scale = size;
 
             volumeDataset.FixDimensions();
+            volumeDataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
         }
     }
 }

--- a/Assets/Scripts/Importing/ImageFileImporter/Nifti.NET/NiftiImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/Nifti.NET/NiftiImporter.cs
@@ -76,9 +76,7 @@ namespace UnityVolumeRendering
             volumeDataset.dimZ = dimZ;
             volumeDataset.datasetName = "test";
             volumeDataset.filePath = filePath;
-            volumeDataset.scaleX = size.x;
-            volumeDataset.scaleY = size.y;
-            volumeDataset.scaleZ = size.z;
+            volumeDataset.scale = size;
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
@@ -79,9 +79,11 @@ namespace UnityVolumeRendering
             volumeDataset.dimZ = (int)size[2];
             volumeDataset.datasetName = "test";
             volumeDataset.filePath = filePath;
-            volumeDataset.scaleX = (float)(spacing[0] * size[0]);
-            volumeDataset.scaleY = (float)(spacing[1] * size[1]);
-            volumeDataset.scaleZ = (float)(spacing[2] * size[2]);
+            volumeDataset.scale = new Vector3(
+                (float)(spacing[0] * size[0]),
+                (float)(spacing[1] * size[1]),
+                (float)(spacing[2] * size[2])
+            );
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
@@ -75,9 +75,9 @@ namespace UnityVolumeRendering
             volumeDataset.datasetName = "test";
             volumeDataset.filePath = filePath;
             volumeDataset.scale = new Vector3(
-                (float)(spacing[0] * size[0]),
-                (float)(spacing[1] * size[1]),
-                (float)(spacing[2] * size[2])
+                (float)(spacing[0] * size[0]) / 1000.0f, // mm to m
+                (float)(spacing[1] * size[1]) / 1000.0f, // mm to m
+                (float)(spacing[2] * size[2]) / 1000.0f // mm to m
             );
 
             // Convert from LPS to Unity's coordinate system

--- a/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
@@ -66,11 +66,6 @@ namespace UnityVolumeRendering
             IntPtr imgBuffer = image.GetBufferAsFloat();
             Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
 
-            // Reverse pixel array.
-            // TODO: Don't do this. Instead, keep the array is it is
-            //  and convert to unity coordinate space by changing the GameObject's scale and rotation.
-            Array.Reverse(pixelData);
-
             spacing = image.GetSpacing();
 
             volumeDataset.data = pixelData;
@@ -84,6 +79,9 @@ namespace UnityVolumeRendering
                 (float)(spacing[1] * size[1]),
                 (float)(spacing[2] * size[2])
             );
+
+            // Convert from LPS to Unity's coordinate system
+            ImporterUtilsInternal.ConvertLPSToUnityCoordinateSpace(volumeDataset);
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
@@ -49,6 +49,9 @@ namespace UnityVolumeRendering
 
             Image image = reader.Execute();
 
+            // Convert to LPS coordinate system (may be needed for NRRD and other datasets)
+            SimpleITK.DICOMOrient(image, "LPS");
+
             // Cast to 32-bit float
             image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
 
@@ -62,8 +65,13 @@ namespace UnityVolumeRendering
             pixelData = new float[numPixels];
             IntPtr imgBuffer = image.GetBufferAsFloat();
             Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
-            spacing = image.GetSpacing();
 
+            // Reverse pixel array.
+            // TODO: Don't do this. Instead, keep the array is it is
+            //  and convert to unity coordinate space by changing the GameObject's scale and rotation.
+            Array.Reverse(pixelData);
+
+            spacing = image.GetSpacing();
 
             volumeDataset.data = pixelData;
             volumeDataset.dimX = (int)size[0];

--- a/Assets/Scripts/Importing/ImageFileImporter/VASP/ParDatasetImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/VASP/ParDatasetImporter.cs
@@ -142,6 +142,7 @@ namespace UnityVolumeRendering
             {
                 dataFiller.data[i] = dataGrid[i];
             }
+            dataFiller.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
         }
 
         private string ParseLine()

--- a/Assets/Scripts/Importing/ImageSequenceImporter/ImageSequenceImporter/ImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/ImageSequenceImporter/ImageSequenceImporter.cs
@@ -211,9 +211,11 @@ namespace UnityVolumeRendering
             dataset.dimX = dimensions.x;
             dataset.dimY = dimensions.y;
             dataset.dimZ = dimensions.z;
-            dataset.scaleX = 1f; // Scale arbitrarily normalised around the x-axis 
-            dataset.scaleY = (float)dimensions.y / (float)dimensions.x;
-            dataset.scaleZ = (float)dimensions.z / (float)dimensions.x;
+            dataset.scale = new Vector3(
+                1f, // Scale arbitrarily normalised around the x-axis 
+                (float)dimensions.y / (float)dimensions.x,
+                (float)dimensions.z / (float)dimensions.x
+            );
         }
 
         

--- a/Assets/Scripts/Importing/ImageSequenceImporter/ImageSequenceImporter/ImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/ImageSequenceImporter/ImageSequenceImporter.cs
@@ -92,6 +92,7 @@ namespace UnityVolumeRendering
             VolumeDataset dataset = FillVolumeDataset(data, dimensions);
 
             dataset.FixDimensions();
+            dataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
 
             return dataset;
         }

--- a/Assets/Scripts/Importing/ImageSequenceImporter/OpenDICOM/DICOMImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/OpenDICOM/DICOMImporter.cs
@@ -222,9 +222,11 @@ namespace UnityVolumeRendering
 
             if (files[0].pixelSpacing > 0.0f)
             {
-                dataset.scaleX = files[0].pixelSpacing * dataset.dimX;
-                dataset.scaleY = files[0].pixelSpacing * dataset.dimY;
-                dataset.scaleZ = Mathf.Abs(files[files.Count - 1].location - files[0].location);
+                dataset.scale = new Vector3(
+                    files[0].pixelSpacing * dataset.dimX,
+                    files[0].pixelSpacing * dataset.dimY,
+                    Mathf.Abs(files[files.Count - 1].location - files[0].location)
+                );
             }
 
             dataset.FixDimensions();

--- a/Assets/Scripts/Importing/ImageSequenceImporter/OpenDICOM/DICOMImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/OpenDICOM/DICOMImporter.cs
@@ -230,6 +230,7 @@ namespace UnityVolumeRendering
             }
 
             dataset.FixDimensions();
+            dataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
         }
 
         private DICOMSliceFile ReadDICOMFile(string filePath)

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -134,7 +134,7 @@ namespace UnityVolumeRendering
             return volumeDataset;
         }
 
-        private void ImportSeriesInternal(VectorString dicomNames, ImageSequenceSeries sequenceSeries, Image image, VectorUInt32 size, float[] pixelData,VolumeDataset volumeDataset)
+        private void ImportSeriesInternal(VectorString dicomNames, ImageSequenceSeries sequenceSeries, Image image, VectorUInt32 size, float[] pixelData, VolumeDataset volumeDataset)
         {
             ImageSeriesReader reader = new ImageSeriesReader();
 
@@ -162,6 +162,12 @@ namespace UnityVolumeRendering
 
             for (int i = 0; i < pixelData.Length; i++)
                 pixelData[i] = Mathf.Clamp(pixelData[i], -1024, 3071);
+
+            // Reverse pixel array, since DICOM uses LPS space.
+            // TODO: Don't do this. Instead, keep the array is it is
+            //  and convert to unity coordinate space by changing the GameObject's scale and rotation.
+            Array.Reverse(pixelData);
+
             VectorDouble spacing = image.GetSpacing();
 
             volumeDataset.data = pixelData;

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -172,9 +172,9 @@ namespace UnityVolumeRendering
             volumeDataset.datasetName = "test";
             volumeDataset.filePath = dicomNames[0];
             volumeDataset.scale = new Vector3(
-                (float)(spacing[0] * size[0]),
-                (float)(spacing[1] * size[1]),
-                (float)(spacing[2] * size[2])
+                (float)(spacing[0] * size[0]) / 1000.0f, // mm to m
+                (float)(spacing[1] * size[1]) / 1000.0f, // mm to m
+                (float)(spacing[2] * size[2]) / 1000.0f // mm to m
             );
 
             // Convert from LPS to Unity's coordinate system

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -177,12 +177,8 @@ namespace UnityVolumeRendering
                 (float)(spacing[2] * size[2])
             );
 
-            volumeDataset.scale = new Vector3(
-                -volumeDataset.scale.x,
-                volumeDataset.scale.y,
-                volumeDataset.scale.z
-            );
-            volumeDataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
+            // Convert from LPS to Unity's coordinate system
+            ImporterUtilsInternal.ConvertLPSToUnityCoordinateSpace(volumeDataset);
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -163,11 +163,6 @@ namespace UnityVolumeRendering
             for (int i = 0; i < pixelData.Length; i++)
                 pixelData[i] = Mathf.Clamp(pixelData[i], -1024, 3071);
 
-            // Reverse pixel array, since DICOM uses LPS space.
-            // TODO: Don't do this. Instead, keep the array is it is
-            //  and convert to unity coordinate space by changing the GameObject's scale and rotation.
-            Array.Reverse(pixelData);
-
             VectorDouble spacing = image.GetSpacing();
 
             volumeDataset.data = pixelData;
@@ -176,9 +171,18 @@ namespace UnityVolumeRendering
             volumeDataset.dimZ = (int)size[2];
             volumeDataset.datasetName = "test";
             volumeDataset.filePath = dicomNames[0];
-            volumeDataset.scaleX = (float)(spacing[0] * size[0]);
-            volumeDataset.scaleY = (float)(spacing[1] * size[1]);
-            volumeDataset.scaleZ = (float)(spacing[2] * size[2]);
+            volumeDataset.scale = new Vector3(
+                (float)(spacing[0] * size[0]),
+                (float)(spacing[1] * size[1]),
+                (float)(spacing[2] * size[2])
+            );
+
+            volumeDataset.scale = new Vector3(
+                -volumeDataset.scale.x,
+                volumeDataset.scale.y,
+                volumeDataset.scale.z
+            );
+            volumeDataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImporterUtilsInternal.cs
+++ b/Assets/Scripts/Importing/ImporterUtilsInternal.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using UnityEngine;
+using System;
+using UnityEditor;
+
+namespace UnityVolumeRendering
+{
+    public class ImporterUtilsInternal
+    {
+        public static void ConvertLPSToUnityCoordinateSpace(VolumeDataset volumeDataset)
+        {
+            volumeDataset.scale = new Vector3(
+                -volumeDataset.scale.x,
+                volumeDataset.scale.y,
+                volumeDataset.scale.z
+            );
+            volumeDataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
+        }
+    }
+}

--- a/Assets/Scripts/Importing/ImporterUtilsInternal.cs.meta
+++ b/Assets/Scripts/Importing/ImporterUtilsInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41fd52e6feb593ff39622dc2f8efeaea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Importing/RawImporter/RawDatasetImporter.cs
+++ b/Assets/Scripts/Importing/RawImporter/RawDatasetImporter.cs
@@ -95,8 +95,7 @@ namespace UnityVolumeRendering
             }
             VolumeDataset dataset = new VolumeDataset();
 
-
-            await Task.Run(() => ImportInternal(dataset,reader,fs));
+            await Task.Run(() => ImportInternal(dataset, reader, fs));
 
             return dataset;
         }
@@ -126,6 +125,7 @@ namespace UnityVolumeRendering
             fs.Close();
 
             dataset.FixDimensions();
+            dataset.rotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
         }
         private int ReadDataValue(BinaryReader reader)
         {

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -24,11 +24,10 @@ namespace UnityVolumeRendering
         public int dimX, dimY, dimZ;
 
         [SerializeField]
-        public float scaleX = 1.0f;
+        public Vector3 scale = Vector3.one;
+
         [SerializeField]
-        public float scaleY = 1.0f;
-        [SerializeField]
-        public float scaleZ = 1.0f;
+        public Quaternion rotation;
         
         public float volumeScale;
 

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Unity.Collections;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace UnityVolumeRendering
 {
@@ -12,7 +13,7 @@ namespace UnityVolumeRendering
     /// An imported dataset. Has a dimension and a 3D pixel array.
     /// </summary>
     [Serializable]
-    public class VolumeDataset : ScriptableObject
+    public class VolumeDataset : ScriptableObject, ISerializationCallbackReceiver
     {
         public string filePath;
         
@@ -42,6 +43,13 @@ namespace UnityVolumeRendering
 
         private SemaphoreSlim createDataTextureLock = new SemaphoreSlim(1, 1);
         private SemaphoreSlim createGradientTextureLock = new SemaphoreSlim(1, 1);
+
+        [SerializeField, System.Obsolete("Use scale instead")]
+        private float scaleX = 1.0f;
+        [SerializeField, System.Obsolete("Use scale instead")]
+        private float scaleY = 1.0f;
+        [SerializeField, System.Obsolete("Use scale instead")]
+        private float scaleZ = 1.0f;
 
         public Texture3D GetDataTexture()
         {
@@ -358,6 +366,19 @@ namespace UnityVolumeRendering
         public float GetData(int x, int y, int z)
         {
             return data[x + y * dimX + z * (dimX * dimY)];
+        }
+
+        public void OnBeforeSerialize()
+        {
+            scaleX = scale.x;
+            scaleY = scale.y;
+            scaleZ = scale.z;
+        }
+
+        public void OnAfterDeserialize()
+        {
+            scale = new Vector3(scaleX, scaleY, scaleZ);
+            Debug.Log(scale);
         }
     }
 }

--- a/Assets/Scripts/VolumeObject/CrossSectionPlane.cs
+++ b/Assets/Scripts/VolumeObject/CrossSectionPlane.cs
@@ -45,7 +45,7 @@ namespace UnityVolumeRendering
 
         public Matrix4x4 GetMatrix()
         {
-            return transform.worldToLocalMatrix * targetObject.transform.localToWorldMatrix;
+            return transform.worldToLocalMatrix * targetObject.volumeContainerObject.transform.localToWorldMatrix;
         }
     }
 }

--- a/Assets/Scripts/VolumeObject/CutoutBox.cs
+++ b/Assets/Scripts/VolumeObject/CutoutBox.cs
@@ -61,7 +61,7 @@ namespace UnityVolumeRendering
 
         public Matrix4x4 GetMatrix()
         {
-            return transform.worldToLocalMatrix * targetObject.transform.localToWorldMatrix;
+            return transform.worldToLocalMatrix * targetObject.volumeContainerObject.transform.localToWorldMatrix;
         }
     }
 }

--- a/Assets/Scripts/VolumeObject/CutoutSphere.cs
+++ b/Assets/Scripts/VolumeObject/CutoutSphere.cs
@@ -30,7 +30,7 @@ public class CutoutSphere : MonoBehaviour, CrossSectionObject
 
     public Matrix4x4 GetMatrix()
     {
-        return transform.worldToLocalMatrix * targetObject.transform.localToWorldMatrix;
+        return transform.worldToLocalMatrix * targetObject.volumeContainerObject.transform.localToWorldMatrix;
     }
 
     private void OnEnable()

--- a/Assets/Scripts/VolumeObject/VolumeObjectFactory.cs
+++ b/Assets/Scripts/VolumeObject/VolumeObjectFactory.cs
@@ -42,7 +42,7 @@ namespace UnityVolumeRendering
             meshContainer.transform.localScale = Vector3.one;
             meshContainer.transform.localPosition = Vector3.zero;
             meshContainer.transform.parent = outerObject.transform;
-            outerObject.transform.localRotation = Quaternion.Euler(90.0f, 0.0f, 0.0f);
+            outerObject.transform.localRotation = Quaternion.Euler(0.0f, 0.0f, 0.0f);
 
             meshRenderer.sharedMaterial = new Material(meshRenderer.sharedMaterial);
             volObj.meshRenderer = meshRenderer;

--- a/Assets/Scripts/VolumeObject/VolumeObjectFactory.cs
+++ b/Assets/Scripts/VolumeObject/VolumeObjectFactory.cs
@@ -12,6 +12,7 @@ namespace UnityVolumeRendering
             VolumeRenderedObject volObj = outerObject.AddComponent<VolumeRenderedObject>();
 
             GameObject meshContainer = GameObject.Instantiate((GameObject)Resources.Load("VolumeContainer"));
+            volObj.volumeContainerObject = meshContainer;
             MeshRenderer meshRenderer = meshContainer.GetComponent<MeshRenderer>();
 
             CreateObjectInternal(dataset,meshContainer, meshRenderer, volObj, outerObject);
@@ -26,6 +27,7 @@ namespace UnityVolumeRendering
             VolumeRenderedObject volObj = outerObject.AddComponent<VolumeRenderedObject>();
 
             GameObject meshContainer = GameObject.Instantiate((GameObject)Resources.Load("VolumeContainer"));
+            volObj.volumeContainerObject = meshContainer;
             MeshRenderer meshRenderer = meshContainer.GetComponent<MeshRenderer>();
 
             CreateObjectInternal(dataset,meshContainer, meshRenderer,volObj,outerObject) ;
@@ -65,11 +67,12 @@ namespace UnityVolumeRendering
             meshRenderer.sharedMaterial.DisableKeyword("MODE_MIP");
             meshRenderer.sharedMaterial.DisableKeyword("MODE_SURF");
 
-            if (dataset.scaleX != 0.0f && dataset.scaleY != 0.0f && dataset.scaleZ != 0.0f)
-            {
-                float maxScale = Mathf.Max(dataset.scaleX, dataset.scaleY, dataset.scaleZ);
-                volObj.transform.localScale = new Vector3(dataset.scaleX / maxScale, dataset.scaleY / maxScale, dataset.scaleZ / maxScale);
-            }
+            meshContainer.transform.localScale = dataset.scale;
+            meshContainer.transform.localRotation = dataset.rotation;
+
+            // Normalise size (TODO: Add setting for diabling this?)
+            float maxScale = Mathf.Max(dataset.scale.x, dataset.scale.y, dataset.scale.z);
+            volObj.transform.localScale = Vector3.one / maxScale;
         }
 
         public static void SpawnCrossSectionPlane(VolumeRenderedObject volobj)

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -48,7 +48,7 @@ namespace UnityVolumeRendering
         public SlicingPlane CreateSlicingPlane()
         {
             GameObject sliceRenderingPlane = GameObject.Instantiate(Resources.Load<GameObject>("SlicingPlane"));
-            sliceRenderingPlane.transform.parent = transform;
+            sliceRenderingPlane.transform.parent = this.volumeContainerObject.transform;
             sliceRenderingPlane.transform.localPosition = Vector3.zero;
             sliceRenderingPlane.transform.localRotation = Quaternion.identity;
             sliceRenderingPlane.transform.localScale = Vector3.one * 0.1f; // TODO: Change the plane mesh instead and use Vector3.one

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -21,6 +21,9 @@ namespace UnityVolumeRendering
         public MeshRenderer meshRenderer;
 
         [SerializeField, HideInInspector]
+        public GameObject volumeContainerObject;
+
+        [SerializeField, HideInInspector]
         private RenderMode renderMode;
         [SerializeField, HideInInspector]
         private TFRenderMode tfRenderMode;

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -286,9 +286,33 @@ namespace UnityVolumeRendering
                 meshRenderer.sharedMaterial.DisableKeyword("CUBIC_INTERPOLATION_ON");
         }
 
+        private void Awake()
+        {
+            // TODO: Remove this after some time. This is to avoid breaking old serialised objects from before volumeContainerObject was added.
+            EnsureVolumeContainerRef();
+        }
+
         private void Start()
         {
             UpdateMaterialProperties();
+        }
+
+        public void OnValidate()
+        {
+            // TODO: Remove this after some time. This is to avoid breaking old serialised objects from before volumeContainerObject was added.
+            EnsureVolumeContainerRef();
+        }
+
+        private void EnsureVolumeContainerRef()
+        {
+            if (volumeContainerObject == null)
+            {
+                Transform trans = this.transform.Find("VolumeContainer");
+                if (trans == null)
+                    trans = this.transform.GetComponentInChildren<MeshRenderer>(true)?.transform;
+                if (trans)
+                    volumeContainerObject = trans.gameObject;
+            }
         }
     }
 }


### PR DESCRIPTION
Hi @SitronX 
Here is my first PR for fixing the coordinate systems. I still need to test more thoroughly, and maybe clean up a few things, but feel free to try it out on your datasets when you have time! 

**Changes:**
- SimpleITK importers: Convert to LPS, and then to Unity's coordinate system
- Changed the transforms of the GameObjects. The "VolumeContainer" object's matrix now converts form local to real coordinates.
- Fixed some issues with the slice renderer, and attached it to the "VolumeContainer" object instead.
- Made the cross section plane tool calculate its' matrix relative to the "VolumeContainer" object, rather than the outer object.

**Explanation of coordinate system transformation:**
Converting from LPS to Unity's coordinate system can be done by the matrix
-1  0  0
0   0  -1
0   1  0
Which is basically the same as scaling by (-1, 0, 0) and rotating by (90, 0, 0).

**Changes to the GameObject transforms**
We have the following hierarchy:
VolumeRenderedObject
 -> VolumeContainer

Previously the VolumeContainer would have a scale of 1 and no rotation, and we would apply all scaling to the parent VolumeRenderedObject.
Now the scaling is done in the VolumeContainer instead, so if you want "real" coordinates you can simply set the scale of the VolumeRenderedObject to 1. This is useful if you want to import and compare several related datasets (received some questions about that before..). So you can import two datasets and their relative sizes to each other should be correct. But by default we downscale the VolumeRenderedObject to a "normalised" size, so that it doesn't become too big.

#166