### PR TITLE
Fix for slice rendering plane looking weird when …

### DIFF
--- a/Assets/Scripts/VolumeObject/SlicingPlane.cs
+++ b/Assets/Scripts/VolumeObject/SlicingPlane.cs
@@ -15,7 +15,7 @@ namespace UnityVolumeRendering
         private void Update()
         {
             meshRenderer.sharedMaterial.SetMatrix("_parentInverseMat", transform.parent.worldToLocalMatrix);
-            meshRenderer.sharedMaterial.SetMatrix("_planeMat", Matrix4x4.TRS(transform.position, transform.rotation, transform.parent.lossyScale)); // TODO: allow changing scale
+            meshRenderer.sharedMaterial.SetMatrix("_planeMat", transform.localToWorldMatrix); // TODO: allow changing scale
         }
     }
 }

--- a/Assets/Shaders/SliceRenderingShader.shader
+++ b/Assets/Shaders/SliceRenderingShader.shader
@@ -45,8 +45,11 @@ Shader "VolumeRendering/SliceRenderingShader"
             {
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
+                // Modified UV (because slicing plane has coodinates between 0 and 100, while the volue mas 0-1)
+                // TODO: Create a different slice mesh!
+                float2 uvMod = float2((0.5f - v.uv.x) * 10.0f, (0.5f - v.uv.y) * 10.0f);
                 // Calculate plane vertex world position.
-                float3 vert = mul(_planeMat, float4(0.5f -v.uv.x, 0.0f, 0.5f -v.uv.y, 1.0f));
+                float3 vert = mul(_planeMat, float4(uvMod.x, 0.0f, uvMod.y, 1.0f));
                 // Convert from world space to volume space.
                 o.relVert = mul(_parentInverseMat, float4(vert, 1.0f));
                 o.uv = v.uv;


### PR DESCRIPTION
Temporary fix for slice rendering plane looking weird when rotating the slice and scaling the model.

**TODO:** Change the slice mesh instead.
We might also want to change how we render these slices. I think it would be cleaner to render them to texture, and then use this texture on the plane mesh and in the slice UI.