### PR TITLE
Optimisation: Added early termination on zero alpha. Removed back-to-front support.

### DIFF
--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -71,14 +71,8 @@ namespace UnityVolumeRendering
             {
                 if (volrendObj.GetRenderMode() == RenderMode.DirectVolumeRendering)
                 {
-                    // Back-to-front rendering option
-                    volrendObj.SetDVRBackwardEnabled(GUILayout.Toggle(volrendObj.GetDVRBackwardEnabled(), "Enable Back-to-Front Direct Volume Rendering"));
-
-                    // Early ray termination for Front-to-back DVR
-                    if (!volrendObj.GetDVRBackwardEnabled())
-                    {
-                        volrendObj.SetRayTerminationEnabled(GUILayout.Toggle(volrendObj.GetRayTerminationEnabled(), "Enable early ray termination"));
-                    }
+                    // Early ray termination
+                    volrendObj.SetRayTerminationEnabled(GUILayout.Toggle(volrendObj.GetRayTerminationEnabled(), "Enable early ray termination"));
                 }
 
                 volrendObj.SetCubicInterpolationEnabled(GUILayout.Toggle(volrendObj.GetCubicInterpolationEnabled(), "Enable cubic interpolation (better quality)"));

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -37,8 +37,6 @@ namespace UnityVolumeRendering
         [SerializeField, HideInInspector]
         private bool rayTerminationEnabled = true;
         [SerializeField, HideInInspector]
-        private bool dvrBackward = false;
-        [SerializeField, HideInInspector]
         private bool cubicInterpolationEnabled = false;
 
         private CrossSectionManager crossSectionManager;
@@ -162,18 +160,16 @@ namespace UnityVolumeRendering
             }
         }
 
+        [System.Obsolete("Back-to-front rendering no longer supported")]
         public bool GetDVRBackwardEnabled()
         {
-            return dvrBackward;
+            return false;
         }
 
+        [System.Obsolete("Back-to-front rendering no longer supported")]
         public void SetDVRBackwardEnabled(bool enable)
         {
-            if (enable != dvrBackward)
-            {
-                dvrBackward = enable;
-                UpdateMaterialProperties();
-            }
+            Debug.LogWarning("Back-to-front rendering no longer supported");
         }
 
         public bool GetCubicInterpolationEnabled()
@@ -274,11 +270,6 @@ namespace UnityVolumeRendering
                 meshRenderer.sharedMaterial.EnableKeyword("RAY_TERMINATE_ON");
             else
                 meshRenderer.sharedMaterial.DisableKeyword("RAY_TERMINATE_ON");
-
-            if (dvrBackward)
-                meshRenderer.sharedMaterial.EnableKeyword("DVR_BACKWARD_ON");
-            else
-                meshRenderer.sharedMaterial.DisableKeyword("DVR_BACKWARD_ON");
 
             if (cubicInterpolationEnabled)
                 meshRenderer.sharedMaterial.EnableKeyword("CUBIC_INTERPOLATION_ON");


### PR DESCRIPTION
Removed support for back-to-front rendering, as this doesn't really serve any purposes anymore.

Also added early termination when alpha is zero after applying transfer function. This makes performance *a lot* better on most datasets, especially when cubic interpolation and lighting is enabled (in direct volume rendering mode).