### PR TITLE
[DO NOT MERGE] Removed ScriptableObject-inheritance from VolumeDataset. Default create material and TF

### DIFF
--- a/Assets/Scripts/Importing/ImageSequenceImporter/ImageSequenceImporter/ImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/ImageSequenceImporter/ImageSequenceImporter.cs
@@ -199,7 +199,6 @@ namespace UnityVolumeRendering
         {
             VolumeDataset dataset = new VolumeDataset();
             string name = Path.GetFileName(directoryPath);
-            dataset.name = name;
 
             await Task.Run(() => FillVolumeInternal(dataset, name, data, dimensions));
           

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -13,7 +13,7 @@ namespace UnityVolumeRendering
     /// An imported dataset. Has a dimension and a 3D pixel array.
     /// </summary>
     [Serializable]
-    public class VolumeDataset : ScriptableObject, ISerializationCallbackReceiver
+    public class VolumeDataset : ISerializationCallbackReceiver
     {
         public string filePath;
         

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -194,6 +194,15 @@ namespace UnityVolumeRendering
 
         private void UpdateMaterialProperties()
         {
+            if (meshRenderer.sharedMaterial == null)
+            {
+                meshRenderer.sharedMaterial = new Material(Shader.Find("VolumeRendering/DirectVolumeRenderingShader"));
+                meshRenderer.sharedMaterial.SetTexture("_DataTex", dataset.GetDataTexture());
+            }
+            if (transferFunction == null)
+            {
+                transferFunction = TransferFunctionDatabase.CreateTransferFunction();
+            }
             UpdateMatAsync();
         }
 


### PR DESCRIPTION
#171

Removed ScriptableObject-inheritance from VolumeDataset. Create default material and TF if null.

**NOTE:** This has one issue: If the `VolumeDataset` is not a ´ScriptableObject´, it will be saved on every `OnInspectorUpdate`, causing terrible performance in editor.