### PR TITLE
Scripted importers (Unity 2020.2+) + prefab support for datasets

### DIFF
--- a/Assets/Editor/DragDropHandler.cs
+++ b/Assets/Editor/DragDropHandler.cs
@@ -1,3 +1,4 @@
+#if UNITY_2021_2_OR_NEWER
 using UnityEditor;
 using UnityEngine;
 
@@ -39,3 +40,4 @@ namespace UnityVolumeRendering
         }
     }
 }
+#endif

--- a/Assets/Editor/DragDropHandler.cs
+++ b/Assets/Editor/DragDropHandler.cs
@@ -15,7 +15,7 @@ namespace UnityVolumeRendering
 
         private static DragAndDropVisualMode OnSceneDrop(Object dropUpon, Vector3 worldPosition, Vector2 viewportPosition, Transform parentForDraggedObjects, bool perform)
         {
-            if (perform)
+            if (perform && DragAndDrop.objectReferences[0] is VolumeDataset)
             {
                 VolumeDataset datasetAsset = (VolumeDataset)DragAndDrop.objectReferences[0];
                 VolumeObjectFactory.CreateObject(datasetAsset);
@@ -25,7 +25,7 @@ namespace UnityVolumeRendering
 
         private static DragAndDropVisualMode OnHierarchyDrop(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects, bool perform)
         {
-            if (perform)
+            if (perform && DragAndDrop.objectReferences[0] is VolumeDataset)
             {
                 VolumeDataset datasetAsset = (VolumeDataset)DragAndDrop.objectReferences[0];
                 VolumeRenderedObject spawnedObject = VolumeObjectFactory.CreateObject(datasetAsset);

--- a/Assets/Editor/DragDropHandler.cs
+++ b/Assets/Editor/DragDropHandler.cs
@@ -1,0 +1,41 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityVolumeRendering
+{
+    static class DragDropHandler
+    {
+        [InitializeOnLoadMethod]
+        static void OnLoad()
+        {
+            DragAndDrop.AddDropHandler(OnSceneDrop);
+            DragAndDrop.AddDropHandler(OnHierarchyDrop);
+        }
+
+        private static DragAndDropVisualMode OnSceneDrop(Object dropUpon, Vector3 worldPosition, Vector2 viewportPosition, Transform parentForDraggedObjects, bool perform)
+        {
+            if (perform)
+            {
+                VolumeDataset datasetAsset = (VolumeDataset)DragAndDrop.objectReferences[0];
+                VolumeObjectFactory.CreateObject(datasetAsset);
+            }
+            return DragAndDropVisualMode.Move;
+        }
+
+        private static DragAndDropVisualMode OnHierarchyDrop(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects, bool perform)
+        {
+            if (perform)
+            {
+                VolumeDataset datasetAsset = (VolumeDataset)DragAndDrop.objectReferences[0];
+                VolumeRenderedObject spawnedObject = VolumeObjectFactory.CreateObject(datasetAsset);
+                GameObject parentObject = (GameObject)EditorUtility.InstanceIDToObject(dropTargetInstanceID);
+                if (parentObject)
+                {
+                    spawnedObject.gameObject.transform.SetParent(parentObject.transform);
+                }
+            }
+
+            return DragAndDropVisualMode.Move;
+        }
+    }
+}

--- a/Assets/Editor/DragDropHandler.cs.meta
+++ b/Assets/Editor/DragDropHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bd42c4d4ac40cd4fbe8a82cbbe38000
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/ScriptedImporters.meta
+++ b/Assets/Editor/ScriptedImporters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5a63e4fcd81601968f6f6594bb0de25
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/ScriptedImporters/ImageFileScriptedImporter.cs
+++ b/Assets/Editor/ScriptedImporters/ImageFileScriptedImporter.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+using UnityEditor.AssetImporters;
+
+namespace UnityVolumeRendering
+{
+#if UVR_USE_SIMPLEITK
+    [ScriptedImporter(1, new string[]{"nrrd", "nii.gz", "nii", "vasp"})]
+#else
+    [ScriptedImporter(1, new string[]{"nii.gz", "nii", "vasp"})]
+#endif
+    public class ImageFileScriptedImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            string fileToImport = ctx.assetPath;
+
+            ImageFileFormat format = GetImageFileFormat(ctx.assetPath);
+            IImageFileImporter importer = ImporterFactory.CreateImageFileImporter(format);
+            VolumeDataset dataset = importer.Import(ctx.assetPath);
+            
+            if (dataset)
+            {
+                ctx.AddObjectToAsset("main obj", dataset);
+                ctx.SetMainObject(dataset);
+            }
+            else
+            {
+                Debug.LogError($"Failed to load dataset: {fileToImport}");
+            }
+        }
+
+        private ImageFileFormat GetImageFileFormat(string filePath)
+        {
+            string extension = System.IO.Path.GetExtension(filePath);
+            switch (extension)
+            {
+                case ".nrrd":
+                    return ImageFileFormat.NRRD;
+                case ".vasp":
+                    return ImageFileFormat.VASP;
+                default:
+                    return ImageFileFormat.NIFTI;
+            }
+        }
+    }
+}

--- a/Assets/Editor/ScriptedImporters/ImageFileScriptedImporter.cs
+++ b/Assets/Editor/ScriptedImporters/ImageFileScriptedImporter.cs
@@ -1,3 +1,4 @@
+#if UNITY_2020_2_OR_NEWER
 using UnityEngine;
 using UnityEditor.AssetImporters;
 
@@ -44,3 +45,4 @@ namespace UnityVolumeRendering
         }
     }
 }
+#endif

--- a/Assets/Editor/ScriptedImporters/ImageFileScriptedImporter.cs.meta
+++ b/Assets/Editor/ScriptedImporters/ImageFileScriptedImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39666708b0e77794a8b38791d59eff8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+using UnityEditor.AssetImporters;
+
+namespace UnityVolumeRendering
+{
+    [ScriptedImporter(1, "raw")]
+    public class RawScriptedImporter : ScriptedImporter
+    {
+        [SerializeField]
+        private Vector3Int dimension = new Vector3Int(128, 256, 256);
+        [SerializeField]
+        private DataContentFormat dataFormat = DataContentFormat.Int16;
+        [SerializeField]
+        private Endianness endianness = Endianness.LittleEndian;
+        [SerializeField]
+        private int bytesToSkip = 0;
+
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            string fileToImport = ctx.assetPath;
+
+            // Try parse ini file (if available)
+            DatasetIniData initData = DatasetIniReader.ParseIniFile(fileToImport + ".ini");
+            if (initData != null)
+            {
+                dimension = new Vector3Int(initData.dimX, initData.dimY, initData.dimZ);
+                dataFormat = initData.format;
+                endianness = initData.endianness;
+                bytesToSkip = initData.bytesToSkip;
+            }
+
+            RawDatasetImporter importer = new RawDatasetImporter(fileToImport, dimension.x, dimension.y, dimension.z, dataFormat, endianness, bytesToSkip);
+            VolumeDataset dataset = importer.Import();
+            
+            if (dataset)
+            {
+                ctx.AddObjectToAsset("main obj", dataset);
+                ctx.SetMainObject(dataset);
+            }
+            else
+            {
+                Debug.LogError($"Failed to load dataset: {fileToImport}");
+            }
+        }
+    }
+}
+

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs
@@ -44,4 +44,3 @@ namespace UnityVolumeRendering
         }
     }
 }
-

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs
@@ -1,3 +1,4 @@
+#if UNITY_2020_2_OR_NEWER
 using UnityEngine;
 using UnityEditor.AssetImporters;
 
@@ -44,3 +45,4 @@ namespace UnityVolumeRendering
         }
     }
 }
+#endif

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs.meta
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2a23bdbfb502dc1cbc4922f66943a8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.AssetImporters;
+
+namespace UnityVolumeRendering
+{
+    [CustomEditor(typeof(RawScriptedImporter))]
+    public class RawScriptedImporterEditor : ScriptedImporterEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            RawScriptedImporter importer = (RawScriptedImporter)target;
+            SerializedProperty dimension = serializedObject.FindProperty("dimension");
+            SerializedProperty dataFormat = serializedObject.FindProperty("dataFormat");
+            SerializedProperty endianness = serializedObject.FindProperty("endianness");
+            SerializedProperty bytesToSkip = serializedObject.FindProperty("bytesToSkip");
+            
+            EditorGUILayout.PropertyField(dimension);
+            EditorGUILayout.PropertyField(dataFormat);
+            EditorGUILayout.PropertyField(endianness);
+            EditorGUILayout.PropertyField(bytesToSkip);
+
+            if (GUILayout.Button("Spawn in scene"))
+            {
+                VolumeDataset datasetAsset = AssetDatabase.LoadAssetAtPath<VolumeDataset>(importer.assetPath);
+                VolumeObjectFactory.CreateObject(datasetAsset);
+            }
+
+            serializedObject.ApplyModifiedProperties();
+
+            ApplyRevertGUI();
+        }
+    }
+}

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using UnityEditor;
 using UnityEditor.AssetImporters;
 
@@ -21,12 +20,6 @@ namespace UnityVolumeRendering
             EditorGUILayout.PropertyField(dataFormat);
             EditorGUILayout.PropertyField(endianness);
             EditorGUILayout.PropertyField(bytesToSkip);
-
-            if (GUILayout.Button("Spawn in scene"))
-            {
-                VolumeDataset datasetAsset = AssetDatabase.LoadAssetAtPath<VolumeDataset>(importer.assetPath);
-                VolumeObjectFactory.CreateObject(datasetAsset);
-            }
 
             serializedObject.ApplyModifiedProperties();
 

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_2020_2_OR_NEWER
 using UnityEditor;
 using UnityEditor.AssetImporters;
 
@@ -27,3 +28,4 @@ namespace UnityVolumeRendering
         }
     }
 }
+#endif

--- a/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs.meta
+++ b/Assets/Editor/ScriptedImporters/RawScriptedImporterEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f88d2f1ec978ec50bb43402fc89ebe15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -13,6 +13,7 @@ namespace UnityVolumeRendering
         private bool otherSettings = true;
         private float currentProgress = 1.0f;
         private string currentProgressDescrition = "";
+        private bool progressDirty = false;
 
         public void StartProgress(string title, string description)
         {
@@ -27,6 +28,11 @@ namespace UnityVolumeRendering
         {
             currentProgressDescrition = description;
             currentProgress = totalProgress;
+            progressDirty = true;
+        }
+        public override bool RequiresConstantRepaint()
+        {
+            return progressDirty;
         }
 
         public override void OnInspectorGUI()
@@ -40,6 +46,7 @@ namespace UnityVolumeRendering
                 GUILayout.Space(18);
                 EditorGUILayout.EndVertical();
             }
+            progressDirty = false;
 
             // Render mode
             RenderMode oldRenderMode = volrendObj.GetRenderMode();

--- a/Assets/Scripts/Importing/ImageFileImporter/Nifti.NET/NiftiImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/Nifti.NET/NiftiImporter.cs
@@ -74,7 +74,7 @@ namespace UnityVolumeRendering
             volumeDataset.dimX = dimX;
             volumeDataset.dimY = dimY;
             volumeDataset.dimZ = dimZ;
-            volumeDataset.datasetName = "test";
+            volumeDataset.datasetName = Path.GetFileName(filePath);
             volumeDataset.filePath = filePath;
             volumeDataset.scale = size;
 

--- a/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
@@ -72,7 +72,7 @@ namespace UnityVolumeRendering
             volumeDataset.dimX = (int)size[0];
             volumeDataset.dimY = (int)size[1];
             volumeDataset.dimZ = (int)size[2];
-            volumeDataset.datasetName = "test";
+            volumeDataset.datasetName = Path.GetFileName(filePath);
             volumeDataset.filePath = filePath;
             volumeDataset.scale = new Vector3(
                 (float)(spacing[0] * size[0]) / 1000.0f, // mm to m

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -169,7 +169,7 @@ namespace UnityVolumeRendering
             volumeDataset.dimX = (int)size[0];
             volumeDataset.dimY = (int)size[1];
             volumeDataset.dimZ = (int)size[2];
-            volumeDataset.datasetName = "test";
+            volumeDataset.datasetName = Path.GetFileName(dicomNames[0]);
             volumeDataset.filePath = dicomNames[0];
             volumeDataset.scale = new Vector3(
                 (float)(spacing[0] * size[0]) / 1000.0f, // mm to m

--- a/Assets/Scripts/Importing/RawImporter/RawDatasetImporter.cs
+++ b/Assets/Scripts/Importing/RawImporter/RawDatasetImporter.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace UnityVolumeRendering
 {
+    [Serializable]
     public enum DataContentFormat
     {
         Int8,
@@ -15,6 +16,7 @@ namespace UnityVolumeRendering
         Uint32
     }
 
+    [Serializable]
     public enum Endianness
     {
         LittleEndian,
@@ -63,7 +65,7 @@ namespace UnityVolumeRendering
                 return null;
             }
 
-            VolumeDataset dataset = new VolumeDataset();
+            VolumeDataset dataset = ScriptableObject.CreateInstance<VolumeDataset>();
             ImportInternal(dataset, reader, fs);
 
             return dataset;

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -385,7 +385,6 @@ namespace UnityVolumeRendering
         public void OnAfterDeserialize()
         {
             scale = new Vector3(scaleX_deprecated, scaleY_deprecated, scaleZ_deprecated);
-            Debug.Log(scale);
         }
     }
 }

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -354,8 +354,8 @@ namespace UnityVolumeRendering
                 return textureTmp;
             }
 
+            progressHandler.StartStage(0.6f, "Creating gradient texture");
             await Task.Run(() => {
-                progressHandler.StartStage(0.6f, "Creating gradient texture");
                 for (int z = 0; z < dimZ; z++)
                 {
                     progressHandler.ReportProgress(z, dimZ, "Calculating gradients for slice");
@@ -370,8 +370,8 @@ namespace UnityVolumeRendering
                         }
                     }
                 }
-                progressHandler.EndStage();
             });
+            progressHandler.EndStage();
 
             progressHandler.StartStage(0.2f, "Uploading gradient texture");
             Texture3D texture = new Texture3D(dimX, dimY, dimZ, texformat, false);

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -194,6 +194,16 @@ namespace UnityVolumeRendering
 
         private void UpdateMaterialProperties()
         {
+            if (meshRenderer.sharedMaterial == null)
+            {
+                meshRenderer.sharedMaterial = new Material(Shader.Find("VolumeRendering/DirectVolumeRenderingShader"));
+                meshRenderer.sharedMaterial.SetTexture("_DataTex", dataset.GetDataTexture());
+            }
+            if (transferFunction == null)
+            {
+                transferFunction = TransferFunctionDatabase.CreateTransferFunction();
+            }
+
             UpdateMatAsync();
         }
 


### PR DESCRIPTION
Datasets can now be saved as assets, either by:
- Dragging file into project (only RAW, NRRD, NIFTI and VASP) - **Only in Unity 2020.2+**
- Right clicking in project view, and selecting "Volume Rendering"->"Import Dataset"

These datasets can easily be dragged and dropped into the scene. **(Only in Unity 2021.2+)**
You can also reference them in some script, and spawn them at runtime.

#171

![image](https://user-images.githubusercontent.com/6906872/234977139-578881d1-0bc4-46a0-a270-1bf830ee5d71.png)

Dataset can be imported from here:
![image](https://user-images.githubusercontent.com/6906872/234977458-7d186c6f-83e4-4d56-b5b7-c7b941474a4b.png)

Imported dataset asset will be available in the project folder:
![image](https://user-images.githubusercontent.com/6906872/234977542-7c080c85-955d-4dd1-869d-9c7f4ded8654.png)

You can drag and drop it into the scene.
