### PR TITLE
Fixed bug with histogram compute shader

### DIFF
--- a/Assets/Resources/ComputeHistogram.compute
+++ b/Assets/Resources/ComputeHistogram.compute
@@ -3,6 +3,7 @@
 
 Texture3D<float> VolumeTexture;
 float ValueRange;
+int3 Dimension;
 
 struct histStruct {
 	uint cnt;
@@ -18,7 +19,10 @@ void HistogramInitialize(uint3 id : SV_DispatchThreadID)
 [numthreads(8, 8, 8)]
 void HistogramMain(uint3 id : SV_DispatchThreadID)
 {
-	uint col = uint(floor(ValueRange * VolumeTexture[id.xyz] + 0.5f));
+	if (id.x < Dimension.x && id.y < Dimension.y & id.z < Dimension.z)
+	{
+		uint col = uint(floor(ValueRange * VolumeTexture[id.xyz] + 0.5f));
 
-	InterlockedAdd(HistogramBuffer[col].cnt, 1);
+		InterlockedAdd(HistogramBuffer[col].cnt, 1);
+	}
 }

--- a/Assets/Scripts/Utils/HistogramTextureGenerator.cs
+++ b/Assets/Scripts/Utils/HistogramTextureGenerator.cs
@@ -72,7 +72,7 @@ namespace UnityVolumeRendering
             Texture3D dataTexture = dataset.GetDataTexture();
 
             if (handleInitialize < 0 || handleMain < 0)
-            { 
+            {
                 Debug.LogError("Histogram compute shader initialization failed.");
             }
 

--- a/Assets/Scripts/Utils/HistogramTextureGenerator.cs
+++ b/Assets/Scripts/Utils/HistogramTextureGenerator.cs
@@ -72,11 +72,12 @@ namespace UnityVolumeRendering
             Texture3D dataTexture = dataset.GetDataTexture();
 
             if (handleInitialize < 0 || handleMain < 0)
-            {
+            { 
                 Debug.LogError("Histogram compute shader initialization failed.");
             }
 
-            computeHistogram.SetFloat("ValueRange", (float)(numValues - 1));
+            computeHistogram.SetFloat("ValueRange", (float)(sampleCount - 1));
+            computeHistogram.SetInts("Dimension", new int[] { dataTexture.width, dataTexture.height, dataTexture.depth });
             computeHistogram.SetTexture(handleMain, "VolumeTexture", dataTexture);
             computeHistogram.SetBuffer(handleMain, "HistogramBuffer", histogramBuffer);
             computeHistogram.SetBuffer(handleInitialize, "HistogramBuffer", histogramBuffer);


### PR DESCRIPTION
Fixes #196

**Changes:**
- Fixed a mistake: Use `sampleCount` instead of `numValues`.
- Prevent out of bounds reads/writes.

**TODO:** Might want to revisit this after Release 4, as well moving gradient calculation to compute shader as well.

**TODO:** `HistogramInitialize` should probably not have only 8 threads per group?