### PR TITLE
Settings for gradient/normal thresholds

### DIFF
--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -61,6 +61,15 @@ namespace UnityVolumeRendering
             EditorGUILayout.MinMaxSlider("Visible value range", ref visibilityWindow.x, ref visibilityWindow.y, 0.0f, 1.0f);
             volrendObj.SetVisibilityWindow(visibilityWindow);
 
+            if (newRenderMode == RenderMode.IsosurfaceRendering)
+            {
+                float oldThreshold = volrendObj.GetGradientVisibilityThreshold();
+                float newThreshold = EditorGUILayout.Slider("Gradient visibility threshold", Mathf.Sqrt(oldThreshold), 0.0f, 1.0f);
+                newThreshold = newThreshold * newThreshold;
+                if (newThreshold != oldThreshold)
+                    volrendObj.SetGradientVisibilityThreshold(newThreshold);
+            }
+
             // Transfer function settings
             EditorGUILayout.Space();
             tfSettings = EditorGUILayout.Foldout(tfSettings, "Transfer function");
@@ -101,6 +110,11 @@ namespace UnityVolumeRendering
                     LightSource newLightSource = (LightSource)EditorGUILayout.EnumPopup("Light source", oldLightSource);
                     if (newLightSource != oldLightSource)
                         volrendObj.SetLightSource(newLightSource);
+
+                    Vector2 gradLightThreshold = volrendObj.GetGradientLightingThreshold();
+                    gradLightThreshold = new Vector2(Mathf.Sqrt(gradLightThreshold.x), Mathf.Sqrt(gradLightThreshold.y));
+                    EditorGUILayout.MinMaxSlider("Visible value range", ref gradLightThreshold.x, ref gradLightThreshold.y, 0.0f, 1.0f);
+                    volrendObj.SetGradientLightingThreshold(new Vector2(gradLightThreshold.x * gradLightThreshold.x, gradLightThreshold.y * gradLightThreshold.y));
                 }
             }
 

--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -64,11 +64,12 @@ namespace UnityVolumeRendering
             if (newRenderMode == RenderMode.IsosurfaceRendering)
             {
                 float oldThreshold = volrendObj.GetGradientVisibilityThreshold();
+                float oldThresholdSqrt = Mathf.Sqrt(oldThreshold); // Convert to square root scaling (=> more precision close to 0)
                 float newThreshold = EditorGUILayout.Slider(
                     new GUIContent("Gradient visibility threshold", "Minimum gradient maginitude value that will be visible"),
-                    Mathf.Sqrt(oldThreshold), 0.0f, 1.0f
+                    oldThresholdSqrt, 0.0f, 1.0f
                 );
-                newThreshold = newThreshold * newThreshold;
+                newThreshold = newThreshold * newThreshold; // Convert back to linear scaling
                 if (newThreshold != oldThreshold)
                     volrendObj.SetGradientVisibilityThreshold(newThreshold);
             }
@@ -114,7 +115,9 @@ namespace UnityVolumeRendering
                     if (newLightSource != oldLightSource)
                         volrendObj.SetLightSource(newLightSource);
 
+                    // Gradient lighting threshold: Threshold for how low gradients can contribute to lighting.
                     Vector2 gradLightThreshold = volrendObj.GetGradientLightingThreshold();
+                    // Convert to square root scaling (=> more precision close to 0)
                     gradLightThreshold = new Vector2(Mathf.Sqrt(gradLightThreshold.x), Mathf.Sqrt(gradLightThreshold.y));
                     EditorGUILayout.MinMaxSlider(
                         new GUIContent("Gradient lighting threshold",
@@ -122,6 +125,7 @@ namespace UnityVolumeRendering
                             + "Voxels with gradient less than min will be unlit, and with gradient >= max will fully shaded."),
                         ref gradLightThreshold.x, ref gradLightThreshold.y, 0.0f, 1.0f
                     );
+                    // Convert back to linear scale, before setting updated value.
                     volrendObj.SetGradientLightingThreshold(new Vector2(gradLightThreshold.x * gradLightThreshold.x, gradLightThreshold.y * gradLightThreshold.y));
                 }
             }

--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -64,7 +64,10 @@ namespace UnityVolumeRendering
             if (newRenderMode == RenderMode.IsosurfaceRendering)
             {
                 float oldThreshold = volrendObj.GetGradientVisibilityThreshold();
-                float newThreshold = EditorGUILayout.Slider("Gradient visibility threshold", Mathf.Sqrt(oldThreshold), 0.0f, 1.0f);
+                float newThreshold = EditorGUILayout.Slider(
+                    new GUIContent("Gradient visibility threshold", "Minimum gradient maginitude value that will be visible"),
+                    Mathf.Sqrt(oldThreshold), 0.0f, 1.0f
+                );
                 newThreshold = newThreshold * newThreshold;
                 if (newThreshold != oldThreshold)
                     volrendObj.SetGradientVisibilityThreshold(newThreshold);
@@ -113,7 +116,12 @@ namespace UnityVolumeRendering
 
                     Vector2 gradLightThreshold = volrendObj.GetGradientLightingThreshold();
                     gradLightThreshold = new Vector2(Mathf.Sqrt(gradLightThreshold.x), Mathf.Sqrt(gradLightThreshold.y));
-                    EditorGUILayout.MinMaxSlider("Visible value range", ref gradLightThreshold.x, ref gradLightThreshold.y, 0.0f, 1.0f);
+                    EditorGUILayout.MinMaxSlider(
+                        new GUIContent("Gradient lighting threshold",
+                            "Minimum and maximum threshold for gradient contribution to lighting.\n"
+                            + "Voxels with gradient less than min will be unlit, and with gradient >= max will fully shaded."),
+                        ref gradLightThreshold.x, ref gradLightThreshold.y, 0.0f, 1.0f
+                    );
                     volrendObj.SetGradientLightingThreshold(new Vector2(gradLightThreshold.x * gradLightThreshold.x, gradLightThreshold.y * gradLightThreshold.y));
                 }
             }

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
 using UnityEngine;
 
 namespace UnityVolumeRendering
@@ -35,18 +34,23 @@ namespace UnityVolumeRendering
         [SerializeField, HideInInspector]
         private LightSource lightSource;
 
+        // Minimum and maximum gradient threshold for lighting contribution. Values below min will be unlit, and between min and max will be partly shaded.
         [SerializeField, HideInInspector]
-        private Vector2 gradientLightingThreshold = new Vector2(0.05f, 0.15f);
+        private Vector2 gradientLightingThreshold = new Vector2(0.02f, 0.15f);
 
+        // Gradient magnitude threshold. Voxels with gradient magnitude less than this will not be rendered in isosurface rendering mode.
         [SerializeField, HideInInspector]
         private float minGradient = 0.01f;
 
+        // Minimum/maximum data value threshold for rendering. Values outside of this range will not be rendered.
         [SerializeField, HideInInspector]
         private Vector2 visibilityWindow = new Vector2(0.0f, 1.0f);
 
+        // Early ray termination
         [SerializeField, HideInInspector]
         private bool rayTerminationEnabled = true;
 
+        // Tri-cubic interpolation of data texture (expensive, but looks better)
         [SerializeField, HideInInspector]
         private bool cubicInterpolationEnabled = false;
 

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -25,17 +25,28 @@ namespace UnityVolumeRendering
 
         [SerializeField, HideInInspector]
         private RenderMode renderMode;
+
         [SerializeField, HideInInspector]
         private TFRenderMode tfRenderMode;
+
         [SerializeField, HideInInspector]
         private bool lightingEnabled;
+
         [SerializeField, HideInInspector]
         private LightSource lightSource;
 
         [SerializeField, HideInInspector]
+        private Vector2 gradientLightingThreshold = new Vector2(0.05f, 0.15f);
+
+        [SerializeField, HideInInspector]
+        private float minGradient = 0.01f;
+
+        [SerializeField, HideInInspector]
         private Vector2 visibilityWindow = new Vector2(0.0f, 1.0f);
+
         [SerializeField, HideInInspector]
         private bool rayTerminationEnabled = true;
+
         [SerializeField, HideInInspector]
         private bool cubicInterpolationEnabled = false;
 
@@ -150,8 +161,39 @@ namespace UnityVolumeRendering
 
         public void SetLightSource(LightSource source)
         {
-            lightSource = source;
-            UpdateMaterialProperties();
+            if (lightSource != source)
+            {
+                lightSource = source;
+                UpdateMaterialProperties();
+            }
+        }
+
+        public void SetGradientLightingThreshold(Vector2 threshold)
+        {
+            if (gradientLightingThreshold != threshold)
+            {
+                gradientLightingThreshold = threshold;
+                UpdateMaterialProperties();
+            }
+        }
+
+        public Vector2 GetGradientLightingThreshold()
+        {
+            return gradientLightingThreshold;
+        }
+
+        public void SetGradientVisibilityThreshold(float min)
+        {
+            if (minGradient != min)
+            {
+                minGradient = min;
+                UpdateMaterialProperties();
+            }
+        }
+
+        public float GetGradientVisibilityThreshold()
+        {
+            return minGradient;
         }
 
         public void SetVisibilityWindow(float min, float max)
@@ -307,6 +349,9 @@ namespace UnityVolumeRendering
 
             meshRenderer.sharedMaterial.SetFloat("_MinVal", visibilityWindow.x);
             meshRenderer.sharedMaterial.SetFloat("_MaxVal", visibilityWindow.y);
+            meshRenderer.sharedMaterial.SetFloat("_MinGradient", minGradient);
+            meshRenderer.sharedMaterial.SetFloat("_LightingGradientThresholdStart", gradientLightingThreshold.x);
+            meshRenderer.sharedMaterial.SetFloat("_LightingGradientThresholdEnd", gradientLightingThreshold.y);
             meshRenderer.sharedMaterial.SetVector("_TextureSize", new Vector3(dataset.dimX, dataset.dimY, dataset.dimZ));
 
             if (rayTerminationEnabled)


### PR DESCRIPTION
# Gradient visibility threshold + gradient lighting threshold

## Gradient lighting threshold

This slider lets you change the minimum and maximum threshold for gradient contribution to lighting.
![image](https://github.com/mlavik1/UnityVolumeRendering/assets/6906872/12d5fc9b-e05a-4079-833c-64e8efe79b18)

Voxels with gradient < min will be unlit. Gradient >= max will be fully shaded. Values in between will be partly shaded (for smooth transitions).

### Results

![image](https://github.com/mlavik1/UnityVolumeRendering/assets/6906872/fc76db20-74ed-44d0-b2c3-c9d096bf2e65)

## Gradient lighting threshold

In isosurface rendering mode, you can now set a minimum gradient magnitude value. Voxels with gradient magnitude less than this will not be rendered.

![image](https://github.com/mlavik1/UnityVolumeRendering/assets/6906872/86cb0b03-bb33-4107-a35c-7d3c6629e7fc)

### Results

![image](https://github.com/mlavik1/UnityVolumeRendering/assets/6906872/88bf182e-8533-4638-a1fe-2b036cffd806)

![image](https://github.com/mlavik1/UnityVolumeRendering/assets/6906872/eca2f3ae-9fa1-41f0-a64d-eaf310e5b01d)
