### PR TITLE
Use SimpleITK for image sequence datasets

### DIFF
--- a/Assets/Editor/VolumeRendererEditorFunctions.cs
+++ b/Assets/Editor/VolumeRendererEditorFunctions.cs
@@ -315,6 +315,11 @@ namespace UnityVolumeRendering
 
                 IEnumerable<IImageSequenceSeries> seriesList = await importer.LoadSeriesAsync(filePaths);
 
+                if (seriesList.Count() == 0)
+                {
+                    Debug.LogWarning("Found no series to import.");
+                }
+
                 foreach (IImageSequenceSeries series in seriesList)
                 {
                     VolumeDataset dataset = await importer.ImportSeriesAsync(series);

--- a/Assets/Scripts/Importing/ImageFileImporter/Interface/IImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/Interface/IImageFileImporter.cs
@@ -7,7 +7,8 @@ namespace UnityVolumeRendering
     {
         VASP,
         NRRD,
-        NIFTI
+        NIFTI,
+        Unknown
     }
 
     /// <summary>

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKDICOMImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKDICOMImporter.cs
@@ -10,10 +10,10 @@ using System.Threading.Tasks;
 namespace UnityVolumeRendering
 {
     /// <summary>
-    /// SimpleITK-based image sequence importer.
-    /// Has support for TIFF and more.
+    /// SimpleITK-based DICOM importer.
+    /// Has support for JPEG2000 and more.
     /// </summary>
-    public class SimpleITKImageSequenceImporter : IImageSequenceImporter
+    public class SimpleITKDICOMImporter : IImageSequenceImporter
     {
         public class ImageSequenceSlice : IImageSequenceFile
         {
@@ -52,20 +52,39 @@ namespace UnityVolumeRendering
 
         private List<ImageSequenceSeries> LoadSeriesInternal(IEnumerable<string> files)
         {
-            ImageSequenceSeries series = new ImageSequenceSeries();
+            HashSet<string> directories = new HashSet<string>();
 
             foreach (string file in files)
             {
-                if (File.Exists(file))
-                {
-                    ImageSequenceSlice sliceFile = new ImageSequenceSlice();
-                    sliceFile.filePath = file;
-                    series.files.Add(sliceFile);
-                }
+                string dir = Path.GetDirectoryName(file);
+                if (!directories.Contains(dir))
+                    directories.Add(dir);
             }
 
             List<ImageSequenceSeries> seriesList = new List<ImageSequenceSeries>();
-            seriesList.Add(series);
+            Dictionary<string, VectorString> directorySeries = new Dictionary<string, VectorString>();
+            foreach (string directory in directories)
+            {
+                VectorString seriesIDs = ImageSeriesReader.GetGDCMSeriesIDs(directory);
+                directorySeries.Add(directory, seriesIDs);
+
+            }
+
+            foreach (var dirSeries in directorySeries)
+            {
+                foreach (string seriesID in dirSeries.Value)
+                {
+                    VectorString dicom_names = ImageSeriesReader.GetGDCMSeriesFileNames(dirSeries.Key, seriesID);
+                    ImageSequenceSeries series = new ImageSequenceSeries();
+                    foreach (string file in dicom_names)
+                    {
+                        ImageSequenceSlice sliceFile = new ImageSequenceSlice();
+                        sliceFile.filePath = file;
+                        series.files.Add(sliceFile);
+                    }
+                    seriesList.Add(series);
+                }
+            }
             return seriesList;
         }
 
@@ -74,6 +93,7 @@ namespace UnityVolumeRendering
             Image image = null;
             float[] pixelData = null;
             VectorUInt32 size = null;
+            VectorString dicomNames = null;
 
             // Create dataset
             VolumeDataset volumeDataset = ScriptableObject.CreateInstance<VolumeDataset>();
@@ -85,7 +105,7 @@ namespace UnityVolumeRendering
                 return null;
             }
 
-            ImportSeriesInternal(sequenceSeries, image, size, pixelData, volumeDataset);
+            ImportSeriesInternal(dicomNames, sequenceSeries, image, size, pixelData, volumeDataset);
 
             return volumeDataset;
         }
@@ -95,6 +115,7 @@ namespace UnityVolumeRendering
             Image image = null;
             float[] pixelData = null;
             VectorUInt32 size = null;
+            VectorString dicomNames = null;
 
             // Create dataset
             VolumeDataset volumeDataset = ScriptableObject.CreateInstance<VolumeDataset>();
@@ -107,57 +128,36 @@ namespace UnityVolumeRendering
                 return null;
             }
 
-            await Task.Run(() => ImportSeriesInternal(sequenceSeries, image, size, pixelData, volumeDataset));
+            await Task.Run(() => ImportSeriesInternal(dicomNames, sequenceSeries, image, size, pixelData, volumeDataset));
 
             return volumeDataset;
         }
 
-        private void ImportSeriesInternal(ImageSequenceSeries sequenceSeries, Image image, VectorUInt32 size, float[] pixelData, VolumeDataset volumeDataset)
+        private void ImportSeriesInternal(VectorString dicomNames, ImageSequenceSeries sequenceSeries, Image image, VectorUInt32 size, float[] pixelData, VolumeDataset volumeDataset)
         {
             ImageSeriesReader reader = new ImageSeriesReader();
 
-            VectorString fileNames = new VectorString();
+            dicomNames = new VectorString();
 
-            foreach (var file in sequenceSeries.files)
-                fileNames.Add(file.filePath);
-            reader.SetFileNames(fileNames);
+            foreach (var dicomFile in sequenceSeries.files)
+                dicomNames.Add(dicomFile.filePath);
+            reader.SetFileNames(dicomNames);
 
             image = reader.Execute();
 
             // Cast to 32-bit float
-            try
-            {
-                image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
+            image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
 
-                size = image.GetSize();
+            size = image.GetSize();
 
-                int numPixels = 1;
-                for (int dim = 0; dim < image.GetDimension(); dim++)
-                    numPixels *= (int)size[dim];
+            int numPixels = 1;
+            for (int dim = 0; dim < image.GetDimension(); dim++)
+                numPixels *= (int)size[dim];
 
-                // Read pixel data
-                pixelData = new float[numPixels];
-                IntPtr imgBuffer = image.GetBufferAsFloat();
-                Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
-            }
-            catch
-            {
-                image = SimpleITK.Cast(image, PixelIDValueEnum.sitkLabelUInt8);
-                Debug.Log("TODO: Hacky workaround");
-                size = image.GetSize();
-
-                int numPixels = 1;
-                for (int dim = 0; dim < image.GetDimension() && dim < 3; dim++)
-                    numPixels *= (int)size[dim];
-
-                // Read pixel data
-                pixelData = new float[numPixels];
-                IntPtr imgBuffer = image.GetBufferAsUInt8();
-                byte[] pixelDataInt8 = new byte[numPixels];
-                Marshal.Copy(imgBuffer, pixelDataInt8, 0, numPixels);
-                for (int i = 0; i < pixelDataInt8.Length; i++)
-                    pixelData[i] = ((ushort)pixelDataInt8[i]) / 255.0f;
-            }
+            // Read pixel data
+            pixelData = new float[numPixels];
+            IntPtr imgBuffer = image.GetBufferAsFloat();
+            Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
 
             for (int i = 0; i < pixelData.Length; i++)
                 pixelData[i] = Mathf.Clamp(pixelData[i], -1024, 3071);
@@ -168,8 +168,8 @@ namespace UnityVolumeRendering
             volumeDataset.dimX = (int)size[0];
             volumeDataset.dimY = (int)size[1];
             volumeDataset.dimZ = (int)size[2];
-            volumeDataset.datasetName = Path.GetFileName(fileNames[0]);
-            volumeDataset.filePath = fileNames[0];
+            volumeDataset.datasetName = Path.GetFileName(dicomNames[0]);
+            volumeDataset.filePath = dicomNames[0];
             volumeDataset.scale = new Vector3(
                 (float)(spacing[0] * size[0]) / 1000.0f, // mm to m
                 (float)(spacing[1] * size[1]) / 1000.0f, // mm to m

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -125,7 +125,7 @@ namespace UnityVolumeRendering
             image = reader.Execute();
 
             // Cast to 32-bit float
-            try
+            if (image.GetDimension() <= 3)
             {
                 image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
 
@@ -140,10 +140,10 @@ namespace UnityVolumeRendering
                 IntPtr imgBuffer = image.GetBufferAsFloat();
                 Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
             }
-            catch
+            else
             {
-                image = SimpleITK.Cast(image, PixelIDValueEnum.sitkLabelUInt8);
-                Debug.Log("TODO: Hacky workaround");
+                // TODO: Find a proper way of handling this
+                Debug.LogWarning("Dataset has more than 3 dimensions. Time-series are not supported. Will try to load first frame");
                 size = image.GetSize();
 
                 int numPixels = 1;

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -124,40 +124,24 @@ namespace UnityVolumeRendering
 
             image = reader.Execute();
 
+            if (image.GetDimension() > 3)
+            {
+                Debug.LogWarning("Dataset has more than 3 dimensions. Time-series are not supported. If this fails, please try import one of the files as an image file");
+            }
+
             // Cast to 32-bit float
-            if (image.GetDimension() <= 3)
-            {
-                image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
+            image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
 
-                size = image.GetSize();
+            size = image.GetSize();
 
-                int numPixels = 1;
-                for (int dim = 0; dim < image.GetDimension(); dim++)
-                    numPixels *= (int)size[dim];
+            int numPixels = 1;
+            for (int dim = 0; dim < image.GetDimension(); dim++)
+                numPixels *= (int)size[dim];
 
-                // Read pixel data
-                pixelData = new float[numPixels];
-                IntPtr imgBuffer = image.GetBufferAsFloat();
-                Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
-            }
-            else
-            {
-                // TODO: Find a proper way of handling this
-                Debug.LogWarning("Dataset has more than 3 dimensions. Time-series are not supported. Will try to load first frame");
-                size = image.GetSize();
-
-                int numPixels = 1;
-                for (int dim = 0; dim < image.GetDimension() && dim < 3; dim++)
-                    numPixels *= (int)size[dim];
-
-                // Read pixel data
-                pixelData = new float[numPixels];
-                IntPtr imgBuffer = image.GetBufferAsUInt8();
-                byte[] pixelDataInt8 = new byte[numPixels];
-                Marshal.Copy(imgBuffer, pixelDataInt8, 0, numPixels);
-                for (int i = 0; i < pixelDataInt8.Length; i++)
-                    pixelData[i] = ((ushort)pixelDataInt8[i]) / 255.0f;
-            }
+            // Read pixel data
+            pixelData = new float[numPixels];
+            IntPtr imgBuffer = image.GetBufferAsFloat();
+            Marshal.Copy(imgBuffer, pixelData, 0, numPixels);
 
             for (int i = 0; i < pixelData.Length; i++)
                 pixelData[i] = Mathf.Clamp(pixelData[i], -1024, 3071);

--- a/Assets/Scripts/Importing/ImporterFactory.cs
+++ b/Assets/Scripts/Importing/ImporterFactory.cs
@@ -65,7 +65,7 @@ namespace UnityVolumeRendering
                 case ImageSequenceFormat.DICOM:
                     {
                         #if UVR_USE_SIMPLEITK
-                        return typeof(SimpleITKImageSequenceImporter);
+                        return typeof(SimpleITKDICOMImporter);
                         #else
                         return typeof(DICOMImporter);
                         #endif

--- a/Assets/Scripts/Importing/ImporterFactory.cs
+++ b/Assets/Scripts/Importing/ImporterFactory.cs
@@ -56,7 +56,11 @@ namespace UnityVolumeRendering
             {
                 case ImageSequenceFormat.ImageSequence:
                     {
+                        #if UVR_USE_SIMPLEITK
+                        return typeof(SimpleITKImageSequenceImporter);
+                        #else
                         return typeof(ImageSequenceImporter);
+                        #endif
                     }
                 case ImageSequenceFormat.DICOM:
                     {

--- a/Assets/Scripts/Importing/ImporterFactory.cs
+++ b/Assets/Scripts/Importing/ImporterFactory.cs
@@ -99,6 +99,14 @@ namespace UnityVolumeRendering
                         return typeof(NiftiImporter);
                         #endif
                     }
+                case ImageFileFormat.Unknown:
+                    {
+#if UVR_USE_SIMPLEITK
+                        return typeof(SimpleITKImageFileImporter);
+#else
+                        return null;
+#endif
+                    }
                 default:
                     return null;
             }


### PR DESCRIPTION
Apparently we were still using the default image sequence importer, even when SimpleITK is enabeld.
The old SimpleITKImageSequenceImporter (which was used for DICOM) couldn't be used directly, so I renamed it to SimpleITKDICOMImporter, and created a copy for other image sequences.

I also did a hack for reading the first frame of 4D datasets. See [EmbryoCE.zip](https://samples.scif.io/EmbryoCE.zip), and others here: https://scif.io/images/