### PR TITLE
Fix prefab saving when overwriting existing prefab

### DIFF
--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -274,7 +274,7 @@ namespace UnityVolumeRendering
                     texture = new Texture3D(dimX, dimY, dimZ, texformat, false);
                     texture.wrapMode = TextureWrapMode.Clamp;
                     texture.SetPixelData(pixelBytes, 0);
-                    texture.Apply();
+                    texture.Apply(false, true);
                     dataTexture = texture;
                     pixelBytes.Dispose();
                 }
@@ -299,7 +299,7 @@ namespace UnityVolumeRendering
                     texture = new Texture3D(dimX, dimY, dimZ, texformat, false);
                     texture.wrapMode = TextureWrapMode.Clamp;
                     texture.SetPixelData(pixelBytes, 0);
-                    texture.Apply();
+                    texture.Apply(false, true);
                     pixelBytes.Dispose();
                 }
             }
@@ -315,7 +315,7 @@ namespace UnityVolumeRendering
                         for (int z = 0; z < dimZ; z++)
                             texture.SetPixel(x, y, z, new Color((float)(data[x + y * dimX + z * (dimX * dimY)] - minValue) / maxRange, 0.0f, 0.0f, 0.0f));
 
-                texture.Apply();
+                texture.Apply(false, true);
             }
             progressHandler.EndStage();
             Debug.Log("Texture generation done.");
@@ -370,7 +370,7 @@ namespace UnityVolumeRendering
                 }
                 progressHandler.EndStage();
                 progressHandler.StartStage(0.2f, "Uploading gradient texture");
-                textureTmp.Apply();
+                textureTmp.Apply(false, true);
 
                 progressHandler.EndStage();
                 Debug.Log("Gradient gereneration done.");
@@ -401,7 +401,7 @@ namespace UnityVolumeRendering
             Texture3D texture = new Texture3D(dimX, dimY, dimZ, texformat, false);
             texture.wrapMode = TextureWrapMode.Clamp;
             texture.SetPixels(cols);
-            texture.Apply();
+            texture.Apply(false, true);
             progressHandler.EndStage();
 
             Debug.Log("Gradient gereneration done.");

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -281,7 +281,7 @@ namespace UnityVolumeRendering
             await UpdateMaterialPropertiesAsync(progressHandler);
         }
 
-        private void UpdateMaterialProperties(IProgressHandler progressHandler = null)
+        public void UpdateMaterialProperties(IProgressHandler progressHandler = null)
         {
             Task task = UpdateMaterialPropertiesAsync(progressHandler);
         }
@@ -293,8 +293,10 @@ namespace UnityVolumeRendering
             try
             {
                 bool useGradientTexture = tfRenderMode == TFRenderMode.TF2D || renderMode == RenderMode.IsosurfaceRendering || lightingEnabled;
-                Texture3D texture = useGradientTexture ? await dataset.GetGradientTextureAsync(progressHandler) : null;
-                meshRenderer.sharedMaterial.SetTexture("_GradientTex", texture);
+                Texture3D gradientTexture = useGradientTexture ? await dataset.GetGradientTextureAsync(progressHandler) : null;
+                Texture3D dataTexture = await dataset.GetDataTextureAsync(progressHandler);
+                meshRenderer.sharedMaterial.SetTexture("_DataTex", dataTexture);
+                meshRenderer.sharedMaterial.SetTexture("_GradientTex", gradientTexture);
                 UpdateMatInternal();
             }
             finally


### PR DESCRIPTION
**Changes:**
- Fix prefab saving when overwriting existing prefab (don't duplicate objects)
- Don't keep volume texture data after uploading to GPU
- Make sure volume data texture always is in sync on material