### PR TITLE
Early return optimisation for volume rendering with tricubic interpolation + adjustable sampling rate multiplier

### DIFF
--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -149,6 +149,7 @@ namespace UnityVolumeRendering
                 }
 
                 volrendObj.SetCubicInterpolationEnabled(GUILayout.Toggle(volrendObj.GetCubicInterpolationEnabled(), "Enable cubic interpolation (better quality)"));
+                volrendObj.SetSamplingRateMultiplier(EditorGUILayout.Slider("Sampling rate multiplier", volrendObj.GetSamplingRateMultiplier(), 0.2f, 2.0f));
             }
         }
     }

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -54,6 +54,10 @@ namespace UnityVolumeRendering
         [SerializeField, HideInInspector]
         private bool cubicInterpolationEnabled = false;
 
+        // Sampling rate multiplier, which affects how many samples are calculated for each ray. Lower values yield better peformance at the cost of visual quality.
+        [SerializeField, HideInInspector]
+        private float samplingRateMultiplier = 1.0f;
+
         private CrossSectionManager crossSectionManager;
 
         private SemaphoreSlim updateMatLock = new SemaphoreSlim(1, 1);
@@ -259,6 +263,20 @@ namespace UnityVolumeRendering
             }
         }
 
+        public float GetSamplingRateMultiplier()
+        {
+            return samplingRateMultiplier;
+        }
+
+        public void SetSamplingRateMultiplier(float value)
+        {
+            if (value != samplingRateMultiplier)
+            {
+                samplingRateMultiplier = value;
+                UpdateMaterialProperties();
+            }
+        }
+
         public void SetTransferFunction(TransferFunction tf)
         {
             this.transferFunction = tf;
@@ -368,6 +386,7 @@ namespace UnityVolumeRendering
 
             meshRenderer.sharedMaterial.SetFloat("_MinVal", visibilityWindow.x);
             meshRenderer.sharedMaterial.SetFloat("_MaxVal", visibilityWindow.y);
+            meshRenderer.sharedMaterial.SetFloat("_SamplingRateMultiplier", samplingRateMultiplier);
             meshRenderer.sharedMaterial.SetFloat("_MinGradient", minGradient);
             meshRenderer.sharedMaterial.SetFloat("_LightingGradientThresholdStart", gradientLightingThreshold.x);
             meshRenderer.sharedMaterial.SetFloat("_LightingGradientThresholdEnd", gradientLightingThreshold.y);


### PR DESCRIPTION
Early return optimisation for volume rendering with tricubic interpolation + adjustable sampling rate multiplier

Two changes:

# Optimised volume rendering tricubic interpolation

We now fetch the density value without tricubic interpolation first, to see if we can do an early return.

This has a minimal cost, but for transfer functions where the lowest density values are mapped to zero then the performance benefit is great (up to 2-3 times faster).

# Sampling rate multiplier setting

Previously I've advised users on very low-end devices (or AR) to modify the "MAX_NUM_STEPS" values in the shader directly, to improve rendering performance at the cost of visual quality. Now there's a setting for this:

![图片](https://github.com/mlavik1/UnityVolumeRendering/assets/6906872/446ca5e2-9fdb-4a3b-a40a-c00e65f9705a)

