### PR TITLE
Replace ImportUtilsInternal.ConvertLPSToUnityCoordinateSpace with SimpleITK.DICOMOrient

### DIFF
--- a/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
+++ b/Assets/Scripts/Importing/ImageFileImporter/SimpleITK/SimpleITKImageFileImporter.cs
@@ -47,8 +47,8 @@ namespace UnityVolumeRendering
 
             Image image = reader.Execute();
 
-            // Convert to LPS coordinate system (may be needed for NRRD and other datasets)
-            SimpleITK.DICOMOrient(image, "LPS");
+            // Convert to Unity's coordinate system (Right, Superior, Anterior)
+            image = SimpleITK.DICOMOrient(image, "RSA");
 
             // Cast to 32-bit float
             image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
@@ -77,9 +77,6 @@ namespace UnityVolumeRendering
                 (float)(spacing[1] * size[1]) / 1000.0f, // mm to m
                 (float)(spacing[2] * size[2]) / 1000.0f // mm to m
             );
-
-            // Convert from LPS to Unity's coordinate system
-            ImporterUtilsInternal.ConvertLPSToUnityCoordinateSpace(volumeDataset);
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKDICOMImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKDICOMImporter.cs
@@ -145,6 +145,9 @@ namespace UnityVolumeRendering
 
             image = reader.Execute();
 
+            // Convert to Unity's coordinate system (Right, Superior, Anterior)
+            image = SimpleITK.DICOMOrient(image, "RSA");
+
             // Cast to 32-bit float
             image = SimpleITK.Cast(image, PixelIDValueEnum.sitkFloat32);
 
@@ -175,9 +178,6 @@ namespace UnityVolumeRendering
                 (float)(spacing[1] * size[1]) / 1000.0f, // mm to m
                 (float)(spacing[2] * size[2]) / 1000.0f // mm to m
             );
-
-            // Convert from LPS to Unity's coordinate system
-            ImporterUtilsInternal.ConvertLPSToUnityCoordinateSpace(volumeDataset);
 
             volumeDataset.FixDimensions();
         }

--- a/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
+++ b/Assets/Scripts/Importing/ImageSequenceImporter/SimpleITK/SimpleITKImageSequenceImporter.cs
@@ -160,9 +160,6 @@ namespace UnityVolumeRendering
                 (float)(spacing[2] * size[2]) / 1000.0f // mm to m
             );
 
-            // Convert from LPS to Unity's coordinate system
-            ImporterUtilsInternal.ConvertLPSToUnityCoordinateSpace(volumeDataset);
-
             volumeDataset.FixDimensions();
         }
     }


### PR DESCRIPTION
DICOM datasets are conventionally structured in a **left posterior superior** (LPS) coordinate space. This means that the X axis increases as it moves leftwards; the Y axis increases as it moves backwards; and the Z axis increases as it moves upwards. Directions are defined in patient coordinate space (PCS), so left refers to the patients left, anterior the patient's anterior, superior the patient's superior.

![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/a102edf6-4e8d-4a02-8789-f3de060506c3)
_Image from https://www.slicer.org/wiki/Coordinate_systems_

Unity, on the other hand, uses a **right superior anterior** coordinate system. Assuming we want to remain in PCS (ie pretend the patient is standing upright rather than lying down) then the Unity coordinate system should look like this:

![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/369f75f0-be98-4a52-87c3-ae3d8a921bad)

The most significant difference between these two coordinate systems is that LPS is a right-handed system while Unity is a left-handed system. This means that, leaving aside any rotation errors, importing DICOM images into Unity without any kind of conversion will result in a volume that's mirror on the X-axis.

UVR currently accounts for this by applying a manual post-import conversion function (`ImporterUtilsInternal.ConvertLPSToUnityCoordinateSpace`) that multiplies the X-axis scale by -1 and applies a 270 degree rotation around the X axis, but this doesn't actually convert the volume into the desired space, and it doesn't do it consistently across different file types. To test this, I took an MRI scan of a volunteer's right foot which was exported as a DICOM dataset, then converted it to NRRD, NIFTI, and a JPEG image sequence before importing all of these formats into UVR.

DICOM | NRRD | NIFTI | JPEG
--- | --- | --- | ---
![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/94c0535c-7df6-4500-b89c-a664656797e1) | ![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/945e942c-fce0-47e0-b420-0fd604cdb19b) | ![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/6bdaf4ab-bb37-4475-bf31-7cc448716246) | ![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/b832f169-4ba5-45f8-bde1-6dfd152664b6)

Although DICOM and NIFTI imported in the same orientation, it's the incorrect orientation - in a PCS, the foot should be upright and the toes pointing forwards (z-positive). NRRD imported upright, but pointing backwards. The JPEG sequence came out inverted on the X axis, suggesting it shouldn't have been inverted.

SimpleITK has a function to allow converting datasets into different coordinate systems - `SimpleITK.DICOMOrient` - before we load them into a Unity Texture3D. Using this function helps ensure that files are loaded into the correct coordinate space without having to apply scene-level rotations or scale transforms. Using the changes made in this PR (removing the existing conversion and replacing it with the SimpleITK function), we get the following outputs:

DICOM | NRRD | NIFTI | JPEG
--- | --- | --- | ---
![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/4b8dc355-4a20-46d0-918a-fd3f6c3a8e62) | ![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/a4a16195-2b29-42e7-8a22-8019ca9108dd) | ![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/e558786d-39b7-43a6-8c28-fe0ffadca0da) | ![image](https://github.com/mlavik1/UnityVolumeRendering/assets/36658325/a36969da-b4a3-41e0-8097-d181fc9ff947)

Note that although the foot is upside down, it's no longer mirrored on the X axis. There might be grounds for applying a rotation to it, but there's only so much that can be done for images sequences because they don't contain any embedded orientation data, so my inclination is to import them as raw as possible.

I've tested the import on a second dataset and confirmed that DICOM, NRRD, and NIFTI imports consistently (image sequence wouldn't load any data, possibly because it's a very faint dataset), but I can't share those images as they're of a patient rather than a volunteer.