### PR TITLE
Add volume normalisation toggle

### DIFF
--- a/Assets/Editor/ImportSettingsEditorWindow.cs
+++ b/Assets/Editor/ImportSettingsEditorWindow.cs
@@ -18,13 +18,24 @@ namespace UnityVolumeRendering
         {
             GUIStyle headerStyle = new GUIStyle(EditorStyles.label);
             headerStyle.fontSize = 20;
+            headerStyle.fixedHeight = 20;
 
             EditorGUILayout.LabelField("Volume rendering import settings", headerStyle);
             EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("Show promt asking if you want to downscale the dataset on import?");
-            bool showDownscalePrompt = EditorGUILayout.Toggle("Show downscale prompt", EditorPrefs.GetBool("DownscaleDatasetPrompt"));
-            EditorPrefs.SetBool("DownscaleDatasetPrompt", showDownscalePrompt);
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Show prompt asking if you want to downscale the dataset on import?");
+            bool showDownscalePrompt = EditorGUILayout.Toggle("", PlayerPrefs.GetInt("DownscaleDatasetPrompt") > 0);
+            PlayerPrefs.SetInt("DownscaleDatasetPrompt", showDownscalePrompt ? 1 : 0);
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Normalise dataset scale on import?");
+            bool normaliseScaleOnImport = EditorGUILayout.Toggle("", PlayerPrefs.GetInt("NormaliseScaleOnImport") > 0);
+            PlayerPrefs.SetInt("NormaliseScaleOnImport", normaliseScaleOnImport ? 1 : 0);
+            EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.Space();
             EditorGUILayout.Space();

--- a/Assets/Scripts/VolumeObject/VolumeObjectFactory.cs
+++ b/Assets/Scripts/VolumeObject/VolumeObjectFactory.cs
@@ -71,9 +71,8 @@ namespace UnityVolumeRendering
             meshContainer.transform.localScale = dataset.scale;
             meshContainer.transform.localRotation = dataset.rotation;
 
-            // Normalise size (TODO: Add setting for diabling this?)
-            float maxScale = Mathf.Max(dataset.scale.x, dataset.scale.y, dataset.scale.z);
-            volObj.transform.localScale = Vector3.one / maxScale;
+            if (PlayerPrefs.GetInt("NormaliseScaleOnImport") > 0)
+                volObj.NormaliseScale();
         }
 
         public static void SpawnCrossSectionPlane(VolumeRenderedObject volobj)

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -97,6 +97,12 @@ namespace UnityVolumeRendering
             await UpdateMaterialPropertiesAsync(progressHandler);
         }
 
+        public void NormaliseScale()
+        {
+            float maxScale = Mathf.Max(dataset.scale.x, dataset.scale.y, dataset.scale.z);
+            transform.localScale = Vector3.one / maxScale;
+        }
+
         public void SetTransferFunctionMode(TFRenderMode mode)
         {
             Task task = SetTransferFunctionModeAsync(mode);


### PR DESCRIPTION
Re. https://github.com/mlavik1/UnityVolumeRendering/issues/201 and https://github.com/mlavik1/UnityVolumeRendering/issues/199

Adds a simple setting that can be toggled to control automatic normalisation of imported datasets. This setting has been placed in PlayerPrefs rather than EditorPrefs so it can be accessed outside the editor. This could potentially be expanded in the future to have overrides for different file types (ie DICOM, NRRD, etc). The setting will default to non-normalisation.

Additional minor changes:
- Fixed line height of the 'Settings' header style so that hanging characters (g, p, etc) aren't truncated
- Enclosed toggles in horizontal groups so that the toggle can be on the same line without truncating the label text
- Moved the existing downscale prompt setting from EditorPrefs to PlayerPrefs to match the new normalisation setting