### PR TITLE
Segmentations + PET overlay

### DIFF
--- a/Assets/3rdparty/Nifti.NET/Nifti.cs
+++ b/Assets/3rdparty/Nifti.NET/Nifti.cs
@@ -135,6 +135,8 @@ namespace Nifti.NET
                 return Array.ConvertAll<short, float>(this.Data as short[], Convert.ToSingle);
             else if(type == typeof(ushort))
                 return Array.ConvertAll<ushort, float>(this.Data as ushort[], Convert.ToSingle);
+            else if (type == typeof(byte))
+                return Array.ConvertAll<byte, float>(this.Data as byte[], Convert.ToSingle);
             else
                 return null;
         }

--- a/Assets/Editor/Utils/EditorDatasetImportUtils.cs
+++ b/Assets/Editor/Utils/EditorDatasetImportUtils.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityVolumeRendering
+{
+    public class EditorDatasetImportUtils
+    {
+        public static async Task<VolumeDataset[]> ImportDicomDirectoryAsync(string dir, ProgressHandler progressHandler)
+        {
+            Debug.Log("Async dataset load. Hold on.");
+
+            List<VolumeDataset> importedDatasets = new List<VolumeDataset>();
+            bool recursive = true;
+
+            // Read all files
+            IEnumerable<string> fileCandidates = Directory.EnumerateFiles(dir, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+                .Where(p => p.EndsWith(".dcm", StringComparison.InvariantCultureIgnoreCase) || p.EndsWith(".dicom", StringComparison.InvariantCultureIgnoreCase) || p.EndsWith(".dicm", StringComparison.InvariantCultureIgnoreCase));
+
+            if (!fileCandidates.Any())
+            {
+                if (UnityEditor.EditorUtility.DisplayDialog("Could not find any DICOM files",
+                    $"Failed to find any files with DICOM file extension.{Environment.NewLine}Do you want to include files without DICOM file extension?", "Yes", "No"))
+                {
+                    fileCandidates = Directory.EnumerateFiles(dir, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                }
+            }
+
+            if (fileCandidates.Any())
+            {
+                progressHandler.StartStage(0.2f, "Loading DICOM series");
+
+                IImageSequenceImporter importer = ImporterFactory.CreateImageSequenceImporter(ImageSequenceFormat.DICOM);
+                IEnumerable<IImageSequenceSeries> seriesList = await importer.LoadSeriesAsync(fileCandidates, new ImageSequenceImportSettings { progressHandler = progressHandler });
+
+                progressHandler.EndStage();
+                progressHandler.StartStage(0.8f);
+
+                int seriesIndex = 0, numSeries = seriesList.Count();
+                foreach (IImageSequenceSeries series in seriesList)
+                {
+                    progressHandler.StartStage(1.0f / numSeries, $"Importing series {seriesIndex + 1} of {numSeries}");
+                    VolumeDataset dataset = await importer.ImportSeriesAsync(series, new ImageSequenceImportSettings { progressHandler = progressHandler });
+                    if (dataset != null)
+                    {
+                        await OptionallyDownscale(dataset);
+                        importedDatasets.Add(dataset);
+                    }
+                    seriesIndex++;
+                    progressHandler.EndStage();
+                }
+
+                progressHandler.EndStage();
+            }
+            else
+                Debug.LogError("Could not find any DICOM files to import.");
+
+            return importedDatasets.ToArray();
+        }
+
+        public static async Task OptionallyDownscale(VolumeDataset dataset)
+        {
+            if (EditorPrefs.GetBool("DownscaleDatasetPrompt"))
+            {
+                if (EditorUtility.DisplayDialog("Optional DownScaling",
+                    $"Do you want to downscale the dataset? The dataset's dimension is: {dataset.dimX} x {dataset.dimY} x {dataset.dimZ}", "Yes", "No"))
+                {
+                    Debug.Log("Async dataset downscale. Hold on.");
+                    await Task.Run(() => dataset.DownScaleData());
+                }
+            }
+        }
+    }
+}

--- a/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
+++ b/Assets/Editor/VolumeRenderedObjectCustomInspector.cs
@@ -142,9 +142,9 @@ namespace UnityVolumeRendering
 
             // Secondary volume
             secondaryVolumeSettings = EditorGUILayout.Foldout(secondaryVolumeSettings, "PET/overlay volume");
-            VolumeDataset secondaryDataset = volrendObj.GetSecondaryDataset();
+            OverlayType overlayType = volrendObj.GetOverlayType();
             TransferFunction secondaryTransferFunction = volrendObj.GetSecondaryTransferFunction();
-            if (secondaryDataset == null)
+            if (overlayType != OverlayType.Overlay)
             {
                 if (GUILayout.Button("Load PET (NRRD, NIFTI)"))
                 {
@@ -164,7 +164,7 @@ namespace UnityVolumeRendering
 
                 if (GUILayout.Button("Remove secondary volume"))
                 {
-                    volrendObj.SetSecondaryDataset(null);
+                    volrendObj.SetOverlayDataset(null);
                 }
             }
 
@@ -177,20 +177,24 @@ namespace UnityVolumeRendering
                 {
                     EditorGUILayout.BeginHorizontal();
                     SegmentationLabel segmentationlabel = segmentationLabels[i];
+                    EditorGUI.BeginChangeCheck();
                     segmentationlabel.name = EditorGUILayout.TextField(segmentationlabel.name);
                     segmentationlabel.colour = EditorGUILayout.ColorField(segmentationlabel.colour);
+                    bool changed = EditorGUI.EndChangeCheck();
                     segmentationLabels[i] = segmentationlabel;
                     if (GUILayout.Button("delete"))
                     {
-                        segmentationLabels.RemoveAt(i);
-                        volrendObj.UpdateSegmentationLabels();
+                        volrendObj.RemoveSegmentation(segmentationlabel.id);
                     }
-                    if (GUILayout.Button("test"))
+                    EditorGUILayout.EndHorizontal();
+                    if (changed)
                     {
                         volrendObj.UpdateSegmentationLabels();
                     }
-                    EditorGUILayout.EndHorizontal();
                 }
+
+                SegmentationRenderMode segmentationRendreMode = (SegmentationRenderMode)EditorGUILayout.EnumPopup("Render mode", volrendObj.GetSegmentationRenderMode());
+                volrendObj.SetSegmentationRenderMode(segmentationRendreMode);
             }
             if (GUILayout.Button("Add segmentation (NRRD, NIFTI)"))
             {
@@ -200,6 +204,10 @@ namespace UnityVolumeRendering
             {
                 ImportSegmentationDicom(volrendObj);
             }*/
+            if (GUILayout.Button("Clear segmentations"))
+            {
+                volrendObj.ClearSegmentations();
+            }
 
             // Other settings
             GUILayout.Space(10);
@@ -242,7 +250,7 @@ namespace UnityVolumeRendering
                 TransferFunction secondaryTransferFunction = ScriptableObject.CreateInstance<TransferFunction>();
                 secondaryTransferFunction.colourControlPoints = new List<TFColourControlPoint>() { new TFColourControlPoint(0.0f, Color.red), new TFColourControlPoint(1.0f, Color.red) };
                 secondaryTransferFunction.GenerateTexture();
-                targetObject.SetSecondaryDataset(importTask.Result);
+                targetObject.SetOverlayDataset(importTask.Result);
                 targetObject.SetSecondaryTransferFunction(secondaryTransferFunction);
             }
         }
@@ -263,7 +271,7 @@ namespace UnityVolumeRendering
                     TransferFunction secondaryTransferFunction = ScriptableObject.CreateInstance<TransferFunction>();
                     secondaryTransferFunction.colourControlPoints = new List<TFColourControlPoint>() { new TFColourControlPoint(0.0f, Color.red), new TFColourControlPoint(1.0f, Color.red) };
                     secondaryTransferFunction.GenerateTexture();
-                    targetObject.SetSecondaryDataset(importTask.Result[0]);
+                    targetObject.SetOverlayDataset(importTask.Result[0]);
                     targetObject.SetSecondaryTransferFunction(secondaryTransferFunction);
                 }
             }

--- a/Assets/Editor/VolumeRendererEditorFunctions.cs
+++ b/Assets/Editor/VolumeRendererEditorFunctions.cs
@@ -33,7 +33,7 @@ namespace UnityVolumeRendering
         [MenuItem("Volume Rendering/Load dataset/Load DICOM")]
         private static void ShowDICOMImporter()
         {
-            DicomImportAsync(true);
+            _ = DicomImportAsync(true);
         }
 
         [MenuItem("Volume Rendering/Load dataset/Load PET-CT DICOM")]
@@ -45,11 +45,12 @@ namespace UnityVolumeRendering
         [MenuItem("Assets/Volume Rendering/Import dataset/Import DICOM")]
         private static void ImportDICOMAsset()
         {
-            DicomImportAsync(false);
+            _ = DicomImportAsync(false);
         }
 
-        private static async void DicomImportAsync(bool spawnInScene)
+        public static async Task<VolumeRenderedObject> DicomImportAsync(bool spawnInScene)
         {
+            VolumeRenderedObject obj = null;
             string dir = EditorUtility.OpenFolderPanel("Select a folder to load", "", "");
             if (Directory.Exists(dir))
             {
@@ -66,7 +67,7 @@ namespace UnityVolumeRendering
                         if (spawnInScene)
                         {
                             VolumeDataset dataset = importTask.Result[i];
-                            VolumeRenderedObject obj = await VolumeObjectFactory.CreateObjectAsync(dataset);
+                            obj = await VolumeObjectFactory.CreateObjectAsync(dataset);
                             obj.transform.position = new Vector3(i, 0, 0);
                         }
                         else
@@ -83,6 +84,7 @@ namespace UnityVolumeRendering
             {
                 Debug.LogError("Directory doesn't exist: " + dir);
             }
+            return obj;
         }
 
         private static async void PETCTDicomImportAsync()

--- a/Assets/Scripts/Importing/Utilities/DatasetFormatUtilities.cs
+++ b/Assets/Scripts/Importing/Utilities/DatasetFormatUtilities.cs
@@ -1,0 +1,21 @@
+namespace UnityVolumeRendering
+{
+    public class DatasetFormatUtilities
+    {
+        public static ImageFileFormat GetImageFileFormat(string filePath)
+        {
+            string extension = System.IO.Path.GetExtension(filePath);
+            switch (extension)
+            {
+                case ".nrrd":
+                    return ImageFileFormat.NRRD;
+                case ".vasp":
+                    return ImageFileFormat.VASP;
+                case ".nii":
+                    return ImageFileFormat.NIFTI;
+                default:
+                    return ImageFileFormat.Unknown;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Importing/Utilities/DatasetFormatUtilities.cs
+++ b/Assets/Scripts/Importing/Utilities/DatasetFormatUtilities.cs
@@ -12,7 +12,8 @@ namespace UnityVolumeRendering
                 case ".vasp":
                     return ImageFileFormat.VASP;
                 case ".nii":
-                    return ImageFileFormat.NIFTI;
+                case ".gz":
+                    return filePath.ToLower().EndsWith(".nii.gz") ? ImageFileFormat.NIFTI : ImageFileFormat.Unknown;
                 default:
                     return ImageFileFormat.Unknown;
             }

--- a/Assets/Scripts/Segmentation/OverlayType.cs
+++ b/Assets/Scripts/Segmentation/OverlayType.cs
@@ -1,0 +1,9 @@
+namespace UnityVolumeRendering
+{
+    public enum OverlayType
+    {
+        None,
+        Overlay,
+        Segmentation
+    }
+}

--- a/Assets/Scripts/Segmentation/SegmentationLabel.cs
+++ b/Assets/Scripts/Segmentation/SegmentationLabel.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace UnityVolumeRendering
+{
+    [System.Serializable]
+    public struct SegmentationLabel
+    {
+        public int id;
+        public string name;
+        public Color colour;
+    }
+}

--- a/Assets/Scripts/Segmentation/SegmentationRenderMode.cs
+++ b/Assets/Scripts/Segmentation/SegmentationRenderMode.cs
@@ -1,0 +1,9 @@
+namespace UnityVolumeRendering
+{
+    [System.Serializable]
+    public enum SegmentationRenderMode
+    {
+        OverlayColour,
+        Isolate
+    }
+}

--- a/Assets/Scripts/VolumeData/VolumeDataset.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataset.cs
@@ -74,6 +74,11 @@ namespace UnityVolumeRendering
             }
         }
 
+        public void RecreateDataTexture()
+        {
+            dataTexture = AsyncHelper.RunSync<Texture3D>(() => CreateTextureInternalAsync(NullProgressHandler.instance));
+        }
+
         /// <summary>
         /// Gets the 3D data texture, containing the density values of the dataset.
         /// Will create the data texture if it does not exist, without blocking the main thread.
@@ -154,6 +159,11 @@ namespace UnityVolumeRendering
             if (maxDataValue == float.MinValue)
                 CalculateValueBounds(new NullProgressHandler());
             return maxDataValue;
+        }
+
+        public void RecalculateBounds()
+        {
+            CalculateValueBounds(new NullProgressHandler());
         }
 
         /// <summary>

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -520,7 +520,7 @@ namespace UnityVolumeRendering
                     meshRenderer.sharedMaterial.EnableKeyword("MULTIVOLUME_ISOLATE");
                     meshRenderer.sharedMaterial.DisableKeyword("MULTIVOLUME_OVERLAY");
                 }
-                else if(overlayType == OverlayType.Overlay)
+                else
                 {
                     meshRenderer.sharedMaterial.EnableKeyword("MULTIVOLUME_OVERLAY");
                     meshRenderer.sharedMaterial.DisableKeyword("MULTIVOLUME_ISOLATE");

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -35,7 +35,10 @@ namespace UnityVolumeRendering
         private LightSource lightSource;
 
         [SerializeField, HideInInspector]
-        private VolumeRenderedObject secondaryVolume;
+        private VolumeDataset secondaryDataset;
+
+        [SerializeField, HideInInspector]
+        private TransferFunction secondaryTransferFunction;
 
         // Minimum and maximum gradient threshold for lighting contribution. Values below min will be unlit, and between min and max will be partly shaded.
         [SerializeField, HideInInspector]
@@ -85,14 +88,25 @@ namespace UnityVolumeRendering
             return slicingPlaneComp;
         }
 
-        public VolumeRenderedObject GetSecondaryVolume()
+        public VolumeDataset GetSecondaryDataset()
         {
-            return this.secondaryVolume;
+            return this.secondaryDataset;
         }
 
-        public void SetSecondaryVolume(VolumeRenderedObject volumeObject)
+        public TransferFunction GetSecondaryTransferFunction()
         {
-            this.secondaryVolume = volumeObject;
+            return this.secondaryTransferFunction;
+        }
+
+        public void SetSecondaryDataset(VolumeDataset dataset)
+        {
+            this.secondaryDataset = dataset;
+            UpdateMaterialProperties();
+        }
+
+        public void SetSecondaryTransferFunction(TransferFunction tf)
+        {
+            this.secondaryTransferFunction = tf;
             UpdateMaterialProperties();
         }
 
@@ -333,7 +347,7 @@ namespace UnityVolumeRendering
                 bool useGradientTexture = tfRenderMode == TFRenderMode.TF2D || renderMode == RenderMode.IsosurfaceRendering || lightingEnabled;
                 Texture3D dataTexture = await dataset.GetDataTextureAsync(progressHandler);
                 Texture3D gradientTexture = useGradientTexture ? await dataset.GetGradientTextureAsync(progressHandler) : null;
-                Texture3D secondaryDataTexture = await secondaryVolume?.dataset?.GetDataTextureAsync(progressHandler);
+                Texture3D secondaryDataTexture = await secondaryDataset?.GetDataTextureAsync(progressHandler);
                 UpdateMatInternal(dataTexture, gradientTexture, secondaryDataTexture);
             }
             finally
@@ -356,7 +370,7 @@ namespace UnityVolumeRendering
 
             if (secondaryDataTexture != null)
             {
-                Texture2D secondaryTF = secondaryVolume.transferFunction.GetTexture();
+                Texture2D secondaryTF = secondaryTransferFunction.GetTexture();
                 meshRenderer.sharedMaterial.SetTexture("_SecondaryDataTex", secondaryDataTexture);
                 meshRenderer.sharedMaterial.SetTexture("_SecondaryTFTex", secondaryTF);
                 meshRenderer.sharedMaterial.EnableKeyword("SECONDARY_VOLUME_ON");

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -85,6 +85,11 @@ namespace UnityVolumeRendering
             return slicingPlaneComp;
         }
 
+        public VolumeRenderedObject GetSecondaryVolume()
+        {
+            return this.secondaryVolume;
+        }
+
         public void SetSecondaryVolume(VolumeRenderedObject volumeObject)
         {
             this.secondaryVolume = volumeObject;

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -1,9 +1,20 @@
-﻿using System.Threading;
+﻿using openDicom.Encoding;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 
 namespace UnityVolumeRendering
 {
+    [System.Serializable]
+    public struct SegmentationLabel
+    {
+        public int id;
+        public string name;
+        public Color colour;
+    }
+
     [ExecuteInEditMode]
     public class VolumeRenderedObject : MonoBehaviour
     {
@@ -39,6 +50,9 @@ namespace UnityVolumeRendering
 
         [SerializeField, HideInInspector]
         private TransferFunction secondaryTransferFunction;
+
+        [SerializeField, HideInInspector]
+        private List<SegmentationLabel> segmentationLabels = new List<SegmentationLabel>();
 
         // Minimum and maximum gradient threshold for lighting contribution. Values below min will be unlit, and between min and max will be partly shaded.
         [SerializeField, HideInInspector]
@@ -93,20 +107,92 @@ namespace UnityVolumeRendering
             return this.secondaryDataset;
         }
 
-        public TransferFunction GetSecondaryTransferFunction()
-        {
-            return this.secondaryTransferFunction;
-        }
-
         public void SetSecondaryDataset(VolumeDataset dataset)
         {
             this.secondaryDataset = dataset;
             UpdateMaterialProperties();
         }
 
+        public TransferFunction GetSecondaryTransferFunction()
+        {
+            return this.secondaryTransferFunction;
+        }
+
         public void SetSecondaryTransferFunction(TransferFunction tf)
         {
             this.secondaryTransferFunction = tf;
+            UpdateMaterialProperties();
+        }
+
+        public List<SegmentationLabel> GetSegmentationLabels()
+        {
+            return segmentationLabels;
+        }
+
+        public void AddSegmentation(VolumeDataset dataset)
+        {
+            if (dataset.data.Length != secondaryDataset.data.Length)
+            {
+                Debug.LogError("Can't add segmentation with different dimension than original dataset.");
+                return;
+            }
+
+            int segmentationId = segmentationLabels.Count > 0 ? segmentationLabels.Max(l => l.id) + 1 : 1;
+
+            if (segmentationLabels.Count == 0)
+            {
+                secondaryDataset = dataset;
+            }
+            else
+            {
+                for (int i = 0; i < secondaryDataset.data.Length; i++)
+                {
+                    secondaryDataset.data[i] = dataset.data[i] > 0.0f ? (float)segmentationId : secondaryDataset.data[i];
+                }
+                secondaryDataset.RecalculateBounds();
+                secondaryDataset.RecreateDataTexture();
+                secondaryDataset.GetDataTexture().filterMode = FilterMode.Point;
+            }
+            SegmentationLabel segmentationLabel = new SegmentationLabel();
+            segmentationLabel.id = segmentationId;
+            segmentationLabel.name = dataset.name;
+            segmentationLabel.colour = Random.ColorHSV();
+            segmentationLabels.Add(segmentationLabel);
+            UpdateSegmentationLabels();
+        }
+
+        public void UpdateSegmentationLabels()
+        {
+            if (segmentationLabels.Count == 0)
+            {
+                return;
+            }
+
+            segmentationLabels.OrderBy(l => l.id);
+            if (secondaryTransferFunction == null)
+            {
+                secondaryTransferFunction = ScriptableObject.CreateInstance<TransferFunction>();
+            }
+            secondaryTransferFunction.alphaControlPoints.Clear();
+            secondaryTransferFunction.colourControlPoints.Clear();
+            int maxSegmentationId = segmentationLabels[segmentationLabels.Count - 1].id;
+            float minDataValue = secondaryDataset.GetMinDataValue();
+            float maxDataValue = secondaryDataset.GetMaxDataValue();
+            secondaryTransferFunction.alphaControlPoints.Add(new TFAlphaControlPoint(0.0f, 0.0f));
+            secondaryTransferFunction.alphaControlPoints.Add(new TFAlphaControlPoint(1.0f, 1.0f));
+            for (int i = 0; i < segmentationLabels.Count; i++)
+            {
+                SegmentationLabel segmentationLabel = segmentationLabels[i];
+                float t = segmentationLabel.id / maxDataValue;
+                secondaryTransferFunction.colourControlPoints.Add(new TFColourControlPoint(t, segmentationLabel.colour));
+                if (i == 0)
+                {
+                    secondaryTransferFunction.alphaControlPoints.Add(new TFAlphaControlPoint(t - 0.01f, 0.0f));
+                    secondaryTransferFunction.alphaControlPoints.Add(new TFAlphaControlPoint(t, 1.0f));
+                }
+            }
+            secondaryTransferFunction.GenerateTexture();
+            secondaryTransferFunction.GetTexture().filterMode = FilterMode.Point;
             UpdateMaterialProperties();
         }
 

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -347,7 +347,7 @@ namespace UnityVolumeRendering
                 bool useGradientTexture = tfRenderMode == TFRenderMode.TF2D || renderMode == RenderMode.IsosurfaceRendering || lightingEnabled;
                 Texture3D dataTexture = await dataset.GetDataTextureAsync(progressHandler);
                 Texture3D gradientTexture = useGradientTexture ? await dataset.GetGradientTextureAsync(progressHandler) : null;
-                Texture3D secondaryDataTexture = await secondaryDataset?.GetDataTextureAsync(progressHandler);
+                Texture3D secondaryDataTexture = secondaryDataset ? await secondaryDataset?.GetDataTextureAsync(progressHandler) : null;
                 UpdateMatInternal(dataTexture, gradientTexture, secondaryDataTexture);
             }
             finally

--- a/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
+++ b/Assets/Scripts/VolumeObject/VolumeRenderedObject.cs
@@ -131,7 +131,7 @@ namespace UnityVolumeRendering
 
         public void AddSegmentation(VolumeDataset dataset)
         {
-            if (dataset.data.Length != secondaryDataset.data.Length)
+            if (secondaryDataset != null && dataset.data.Length != secondaryDataset.data.Length)
             {
                 Debug.LogError("Can't add segmentation with different dimension than original dataset.");
                 return;

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -18,5 +18,7 @@ Texture downscaling, optimisation.
 Async loading
 - [Riccardo Lops](https://github.com/riccardolops)
 Modified shader to handle stereo rendering.
+- [Juan Pablo Montoya](https://github.com/JuanPabloMontoya271)
+Overlay Segmentations - initial implementation
 
 Feel free to add yourself to this list when contributing to this project.


### PR DESCRIPTION
#249

Add support for PET overlays and segmentation labels.

**Features:**
- Import PET dataset (and use separate transfer function for this)
- Import segmentation
- Combine imported segmentations automatically
- Set colour for each segmentation labels
- Segmentation render modes: Overlay and isolated

**TODO:**
- Allow creating a transfer function for each segmentation label (stack these on top of each other in final combined TF - note: Will need point filtering mode for that)

![image](https://github.com/user-attachments/assets/f69fe6d6-96e8-45cf-ba55-7f997d9b03ec)

Datasets for testing:
- Segmentations: https://zenodo.org/records/8367088
- PET/CT: https://www.aliza-dicom-viewer.com/download/datasets (see "TCIA, Siemens, PET study")
