### PR TITLE
Protection level for Texture2D variable defined in TransferFunction.cs

### DIFF
--- a/Assets/Scripts/TransferFunction/TransferFunction.cs
+++ b/Assets/Scripts/TransferFunction/TransferFunction.cs
@@ -12,7 +12,7 @@ namespace UnityVolumeRendering
         [SerializeField]
         public List<TFAlphaControlPoint> alphaControlPoints = new List<TFAlphaControlPoint>();
 
-        private Texture2D texture = null;
+        protected Texture2D texture = null;
         private Color[] tfCols;
 
         private const int TEXTURE_WIDTH = 1024;

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -20,5 +20,7 @@ Async loading
 Modified shader to handle stereo rendering.
 - [Juan Pablo Montoya](https://github.com/JuanPabloMontoya271)
 Overlay Segmentations - initial implementation
+- [Vijay Kalivarapu](https://github.com/kvijaykiran)
+Texture2D variable in TransferFunction changed to protected - to allow for custom texture creation
 
 Feel free to add yourself to this list when contributing to this project.


### PR DESCRIPTION
Changed the protection level for Texture2D variable defined in TransferFunction.cs from private to protected. This change will allow for making 3rd party changes or customizations to transfer function creation as well as texture processing.

Without this change, I can only create a scriptable instance of TransferFunction in my own implementation, but Texture2Ds that I define and make changes to, do not get propagated to UnityVolumeRendering's workflow. I see a GetTexture() but did not find any SetTexture() that allows injecting my own texture.

Using a protected Texture2D variable will allow for inheriting the variable from TransferFunction class.