### PR TITLE
Moved manifest file to the root directory of the plugin

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "com.unity.modules.imageconversion": "1.0.0",
-    "com.unity.modules.imgui": "1.0.0",
-    "com.unity.modules.jsonserialize": "1.0.0"
-  }
-}


### PR DESCRIPTION
Instructions to pull a plugin directly from a git URL say that the file manifest.json should be in the root directory instead of 'Packages'. I moved the file to the root directory. I do not know if this will work, but I wanted to give this a try. 